### PR TITLE
Fix refresh test

### DIFF
--- a/tests/FOS/HttpCache/Tests/Functional/Fixtures/varnish/fos.vcl
+++ b/tests/FOS/HttpCache/Tests/Functional/Fixtures/varnish/fos.vcl
@@ -35,6 +35,10 @@ sub vcl_recv {
 
         error 200 "Banned";
     }
+
+    if (req.http.Cache-Control ~ "no-cache" && client.ip ~ invalidators) {
+        set req.hash_always_miss = true;
+    }
 }
 
 sub vcl_fetch {

--- a/tests/FOS/HttpCache/Tests/Functional/Fixtures/web/cache.php
+++ b/tests/FOS/HttpCache/Tests/Functional/Fixtures/web/cache.php
@@ -2,3 +2,5 @@
 header('Cache-Control: max-age=3600');
 header('Content-Type: text/html');
 header('X-Cache-Debug: 1');
+
+echo microtime(true);

--- a/tests/FOS/HttpCache/Tests/Functional/VarnishTest.php
+++ b/tests/FOS/HttpCache/Tests/Functional/VarnishTest.php
@@ -95,10 +95,9 @@ class VarnishTest extends VarnishTestCase
         $this->assertHit($response);
 
         $this->varnish->refresh('/cache.php')->flush();
-
-        sleep(1);
+        usleep(1000);
         $refreshed = self::getResponse('/cache.php');
-        $this->assertGreaterThan((string) $response->getHeader('Age'), (string) $refreshed->getHeader('Age'));
+        $this->assertGreaterThan((float) $response->getBody(true), (float) $refreshed->getBody(true));
     }
 
     public function testRefreshContentType()


### PR DESCRIPTION
Refresh hadn't yet been added to our VCL, so the test was succeeding while it shouldn't. This PR adds refresh to VCL and fixes test.
