### PR TITLE
Simplify test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,11 +7,8 @@
          convertWarningsToExceptions="true"
          syntaxCheck="true">
     <testsuites>
-        <testsuite name="unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="functional">
-            <directory suffix="Test.php">./tests/Functional</directory>
+        <testsuite name="FOSHttpCache tests">
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 
@@ -22,12 +19,8 @@
     </filter>
 
     <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener"/>
-        <listener class="\FOS\HttpCache\Tests\Functional\WebServerListener">
-            <arguments>
-                <string>functional</string>
-            </arguments>
-        </listener>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
+        <listener class="\FOS\HttpCache\Tests\Functional\WebServerListener" />
     </listeners>
 
     <php>

--- a/tests/Functional/CacheInvalidatorTest.php
+++ b/tests/Functional/CacheInvalidatorTest.php
@@ -5,6 +5,9 @@ namespace FOS\HttpCache\Tests\Functional;
 use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCache\Tests\VarnishTestCase;
 
+/**
+ * @group webserver
+ */
 class CacheInvalidatorTest extends VarnishTestCase
 {
     public function testInvalidateTags()

--- a/tests/Functional/VarnishTest.php
+++ b/tests/Functional/VarnishTest.php
@@ -5,6 +5,9 @@ namespace FOS\HttpCache\Tests\Functional;
 use FOS\HttpCache\Invalidation\Varnish;
 use FOS\HttpCache\Tests\VarnishTestCase;
 
+/**
+ * @group webserver
+ */
 class VarnishTest extends VarnishTestCase
 {
     public function testBanAll()
@@ -29,7 +32,7 @@ class VarnishTest extends VarnishTestCase
         $this->varnish->ban(array(Varnish::HTTP_HEADER_HOST => 'wrong-host.lo'))->flush();
         $this->assertHit($this->getResponse('/cache.php'));
 
-        $this->varnish->ban(array(Varnish::HTTP_HEADER_HOST => WEB_SERVER_HOSTNAME))->flush();
+        $this->varnish->ban(array(Varnish::HTTP_HEADER_HOST => $this->getHostname()))->flush();
         $this->assertMiss($this->getResponse('/cache.php'));
     }
 


### PR DESCRIPTION
This PR simplifies the tests by:
- removing the need for differentiation between the unit and functional test suite (those are already in separate directories)
- having a cleaner `phpunit.xml.dist` and `WebServerListener`.

Additionally, running single test classes is now possible. Previously, this didn’t work:

``` bash
$ phpunit tests/Functional/VarnishTest.php
```
