### PR TITLE
Empty queue on flush even if exceptions occur

### DIFF
--- a/src/Invalidation/Varnish.php
+++ b/src/Invalidation/Varnish.php
@@ -211,12 +211,13 @@ class Varnish implements BanInterface, PurgeInterface, RefreshInterface
      */
     public function flush()
     {
-        if (0 === count($this->queue)) {
+        $queue = $this->queue;
+        if (0 === count($queue)) {
             return;
         }
 
-        $this->sendRequests($this->queue);
         $this->queue = array();
+        $this->sendRequests($queue);
     }
 
     /**

--- a/tests/Unit/Invalidation/VarnishTest.php
+++ b/tests/Unit/Invalidation/VarnishTest.php
@@ -118,17 +118,23 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $mock = new MockPlugin();
         $mock->addException(new CurlException('connect to host'));
 
-        $client = new Client('');
+        $client = new Client();
         $client->addSubscriber($mock);
 
         $varnish = new Varnish(array('http://127.0.0.1:123'), 'my_hostname.dev', $client);
 
         try {
-            $varnish->purge('/test/this/a')->flush();
+            $varnish->purge('/paths')->flush();
         } catch (ExceptionCollection $exceptions) {
             $this->assertCount(1, $exceptions);
             $this->assertInstanceOf('\FOS\HttpCache\Exception\ProxyUnreachableException', $exceptions->getFirst());
         }
+
+        $mock->clearQueue();
+        $mock->addResponse(new Response(200));
+
+        // Queue must now be empty, so exception above must not be thrown again.
+        $varnish->purge('/path')->flush();
     }
 
     /**


### PR DESCRIPTION
As discussed in #34.
