### PR TITLE
add a supports method to the cache invalidator

### DIFF
--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -22,6 +22,21 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class CacheInvalidator
 {
     /**
+     * Value to check support of invalidatePath operation.
+     */
+    const PATH = 'path';
+
+    /**
+     * Value to check support of refreshPath operation.
+     */
+    const REFRESH = 'refresh';
+
+    /**
+     * Value to check support of invalidate operation.
+     */
+    const INVALIDATE = 'invalidate';
+
+    /**
      * @var CacheProxyInterface
      */
     protected $cache;
@@ -44,6 +59,34 @@ class CacheInvalidator
     public function __construct(CacheProxyInterface $cache)
     {
         $this->cache = $cache;
+    }
+
+    /**
+     * Check whether this invalidator instance supports the specified
+     * operation.
+     *
+     * Support for PATH means invalidatePath will work, REFRESH means
+     * refreshPath works and INVALIDATE is about all other invalidation
+     * methods.
+     *
+     * @param string $operation one of the class constants.
+     *
+     * @return bool
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function supports($operation)
+    {
+        switch($operation) {
+            case self::PATH:
+                return $this->cache instanceof PurgeInterface;
+            case self::REFRESH:
+                return $this->cache instanceof RefreshInterface;
+            case self::INVALIDATE:
+                return $this->cache instanceof BanInterface;
+            default:
+                throw new \InvalidArgumentException('Unknown operation ' . $operation);
+        }
     }
 
     /**

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -8,10 +8,45 @@ use FOS\HttpCache\Exception\ExceptionCollection;
 use FOS\HttpCache\Exception\ProxyResponseException;
 use FOS\HttpCache\Exception\ProxyUnreachableException;
 use FOS\HttpCache\Exception\UnsupportedInvalidationMethodException;
+use FOS\HttpCache\Invalidation\Varnish;
 use \Mockery;
 
 class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 {
+    public function testSupportsTrue()
+    {
+        $httpCache = new Varnish(array('localhost'));
+
+        $cacheInvalidator = new CacheInvalidator($httpCache);
+
+        $this->assertTrue($cacheInvalidator->supports(CacheInvalidator::PATH));
+        $this->assertTrue($cacheInvalidator->supports(CacheInvalidator::REFRESH));
+        $this->assertTrue($cacheInvalidator->supports(CacheInvalidator::INVALIDATE));
+    }
+
+    public function testSupportsFalse()
+    {
+        $httpCache = \Mockery::mock('\FOS\HttpCache\Invalidation\CacheProxyInterface');
+
+        $cacheInvalidator = new CacheInvalidator($httpCache);
+
+        $this->assertFalse($cacheInvalidator->supports(CacheInvalidator::PATH));
+        $this->assertFalse($cacheInvalidator->supports(CacheInvalidator::REFRESH));
+        $this->assertFalse($cacheInvalidator->supports(CacheInvalidator::INVALIDATE));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSupportsInvalid()
+    {
+        $httpCache = \Mockery::mock('\FOS\HttpCache\Invalidation\CacheProxyInterface');
+
+        $cacheInvalidator = new CacheInvalidator($httpCache);
+
+        $cacheInvalidator->supports('garbage');
+    }
+
     public function testInvalidatePath()
     {
         $httpCache = \Mockery::mock('\FOS\HttpCache\Invalidation\Method\PurgeInterface')


### PR DESCRIPTION
As we do not expose the cache proxy interfaces in the invalidator, i thought it could make sense to have a way to check what will be supported. This will be useful for generic bundles that integrate with caching (thinking about the symfony cmf for example here)

If you agree with the idea and implementation, i can add some tests (though its pretty straightforward)
