### PR TITLE
Remove "esi" keyword from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "friendsofsymfony/http-cache",
     "type": "library",
     "description": "Tools to manage cache invalidation",
-    "keywords": [ "http", "caching", "purge", "invalidation", "varnish", "esi" ],
+    "keywords": [ "http", "caching", "purge", "invalidation", "varnish" ],
     "homepage": "https://github.com/friendsofsymfony/FOSHttpCache",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
I don't think our library has anything to do with ESI, so let's remove the keyword.
