### PR TITLE
Fix test with phpunit > 3.7

### DIFF
--- a/tests/Functional/WebServerListener.php
+++ b/tests/Functional/WebServerListener.php
@@ -58,6 +58,7 @@ class WebServerListener implements \PHPUnit_Framework_TestListener
     public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
     public function startTest(\PHPUnit_Framework_Test $test) {}
     public function endTest(\PHPUnit_Framework_Test $test, $time) {}
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
 
     /**
      * Get web server hostname


### PR DESCRIPTION
This PR allow phpunit > 3.7 to be used for running the test, it also work with phpunit 3.7.x versions.
