### PR TITLE
cache tag invalidation needs to escape for regex

### DIFF
--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -282,7 +282,7 @@ class CacheInvalidator
             throw UnsupportedProxyOperationException::cacheDoesNotImplement('BAN');
         }
 
-        $headers = array($this->getTagsHeader() => '('.implode('|', $tags).')(,.+)?$');
+        $headers = array($this->getTagsHeader() => '('.implode('|', array_map('preg_quote', $tags)).')(,.+)?$');
         $this->cache->ban($headers);
 
         return $this;

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -119,7 +119,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
     {
         $ban = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\BanInterface')
             ->shouldReceive('ban')
-            ->with(array('X-Cache-Tags' => '(post-1|posts)(,.+)?$'))
+            ->with(array('X-Cache-Tags' => '(post\-1|posts)(,.+)?$'))
             ->once()
             ->getMock();
 
@@ -131,7 +131,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
     {
         $ban = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\BanInterface')
             ->shouldReceive('ban')
-            ->with(array('Custom-Tags' => '(post-1)(,.+)?$'))
+            ->with(array('Custom-Tags' => '(post\-1)(,.+)?$'))
             ->once()
             ->getMock();
 


### PR DESCRIPTION
stumbled over this problem with a tag `[product/42]` that was not invalidated
