### PR TITLE
debug information in exceptions

### DIFF
--- a/src/Exception/ProxyResponseException.php
+++ b/src/Exception/ProxyResponseException.php
@@ -19,22 +19,23 @@ class ProxyResponseException extends \RuntimeException implements HttpCacheExcep
     /**
      * @param string     $host          The host name that was contacted.
      * @param string     $statusCode    The status code of the reply.
-     * @param string     $statusMessage The content of the reply.
-     * @param \Exception $previous      The exception from guzzle.
+     * @param string     $statusMessage The error message.
+     * @param string     $details  Further details about the request that caused the error.
+     * @param \Exception $previous      The exception from the HTTP client.
      *
      * @return ProxyUnreachableException
      */
-    public static function proxyResponse($host, $statusCode, $statusMessage, \Exception $previous = null)
+    public static function proxyResponse($host, $statusCode, $statusMessage, $details = '', \Exception $previous = null)
     {
-        return new ProxyResponseException(
-            sprintf(
-                '%s error response "%s" from caching proxy at %s',
-                $statusCode,
-                $statusMessage,
-                $host
-            ),
+        $message = sprintf(
+            '%s error response "%s" from caching proxy at %s',
             $statusCode,
-            $previous
+            $statusMessage,
+            $host
         );
+        if ($details) {
+            $message .= ". $details";
+        }
+        return new ProxyResponseException($message, $statusCode, $previous);
     }
 }

--- a/src/Exception/ProxyUnreachableException.php
+++ b/src/Exception/ProxyUnreachableException.php
@@ -19,19 +19,25 @@ class ProxyUnreachableException extends \RuntimeException implements HttpCacheEx
 {
     /**
      * @param string     $host     The host name that was contacted.
-     * @param string     $message  The error message from guzzle.
-     * @param \Exception $previous The exception from guzzle.
+     * @param string     $message  The error message from the HTTP client.
+     * @param string     $details  Further details about the request that caused the error.
+     * @param \Exception $previous The exception from the HTTP client.
      *
      * @return ProxyUnreachableException
      */
-    public static function proxyUnreachable($host, $message, \Exception $previous = null)
+    public static function proxyUnreachable($host, $message, $details = '', \Exception $previous = null)
     {
+        $message = sprintf(
+            'Request to caching proxy at %s failed with message "%s"',
+            $host,
+            $message
+        );
+        if ($details) {
+            $message .= ". $details";
+        }
+
         return new ProxyUnreachableException(
-            sprintf(
-                'Request to caching proxy at %s failed with message "%s"',
-                $host,
-                $message
-            ),
+            $message,
             0,
             $previous
         );

--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -195,6 +195,7 @@ abstract class AbstractProxyClient implements ProxyClientInterface
                 $e = ProxyUnreachableException::proxyUnreachable(
                     $exception->getRequest()->getHost(),
                     $exception->getMessage(),
+                    $exception->getRequest()->getRawHeaders(),
                     $exception
                 );
             } elseif ($exception instanceof RequestException) {
@@ -203,6 +204,7 @@ abstract class AbstractProxyClient implements ProxyClientInterface
                     $exception->getRequest()->getHost(),
                     $exception->getCode(),
                     $exception->getMessage(),
+                    $exception->getRequest()->getRawHeaders(),
                     $exception
                 );
             } else {


### PR DESCRIPTION
the log entries in symfony log for example show something like this when a request failed:

```
[2014-07-16 14:27:37] app.CRITICAL: 0 error response "Client error response [status code] 401 
[reason phrase] Unauthorized [url] http://127.0.0.1/" from caching proxy at 127.0.0.1 {"exception":"
[object] (FOS\\HttpCache\\Exception\\ProxyResponseException: 0 error response \"Client error 
response\n[status code] 401\n[reason phrase] Unauthorized\n[url] http://127.0.0.1/\" from caching 
proxy at 127.0.0.1 at /vagrant/vendor/friendsofsymfony/http-cache/src/Exception
/ProxyResponseException.php:29, Guzzle\\Http\\Exception\\ClientErrorResponseException: Client error 
response\n[status code] 401\n[reason phrase] Unauthorized\n[url] http://127.0.0.1/ at /vagrant/vendor
/guzzle/guzzle/src/Guzzle/Http/Exception/BadResponseException.php:43)"} []
```

this is not exactly helpful to figure out what was going on. this POC adds information what was actually sent to the server:

```
BAN / HTTP/1.1 Host: migrosapi.lo X-Host: .* X-Url: .* X-Content-Type: .* X-Cache-Tags: (my-tag)
(,.+)?$ User-Agent: Guzzle/3.8.1 curl/7.19.7 PHP/5.5.12 Content-Length: 0 
```

maybe [twitter](https://twitter.com/dbu/status/489385378252869633) will find a good suggestion how to format this as curl command line. otherwise we can attempt something ourselves or just format this a bit more nicely.
