### PR TITLE
Fix purge syntax for Varnish 4.0.1

### DIFF
--- a/tests/AbstractProxyClientTestCase.php
+++ b/tests/AbstractProxyClientTestCase.php
@@ -32,7 +32,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     const CACHE_HIT  = 'HIT';
 
     /**
-     * A guzzle http client.
+     * A Guzzle HTTP client.
      *
      * @var Client
      */
@@ -65,6 +65,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
      *
      * @param string $url
      * @param array  $headers
+     * @param array  $options
      *
      * @return Response
      */
@@ -81,7 +82,10 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     public function getClient()
     {
         if (null === $this->client) {
-            $this->client = new Client('http://' . $this->getHostName() . ':' . $this->getCachingProxyPort());
+            $this->client = new Client(
+                'http://' . $this->getHostName() . ':' . $this->getCachingProxyPort(),
+                array('curl.options' => array(CURLOPT_FORBID_REUSE => true))
+            );
         }
 
         return $this->client;

--- a/tests/Functional/Fixtures/varnish-4/purge.vcl
+++ b/tests/Functional/Fixtures/varnish-4/purge.vcl
@@ -3,22 +3,6 @@ sub vcl_recv {
         if (!client.ip ~ invalidators) {
             return (synth(405, "Not allowed"));
         }
-        return (hash);
-    }
-}
-
-sub vcl_hit {
-    if (req.method == "PURGE") {
-        purge;
-        return (synth(204, "Purged"));
-    }
-}
-
-# The purge in vcl_miss is necessary to purge all variants in the cases where
-# you hit an object, but miss a particular variant.
-sub vcl_miss {
-    if (req.method == "PURGE") {
-        purge;
-        return (synth(204, "Purged (Not in cache)"));
+        return (purge);
     }
 }


### PR DESCRIPTION
This fixes #97.
