### PR TITLE
Note that base URL should include port

### DIFF
--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -28,6 +28,11 @@ is available as the second parameter::
 
     $varnish = new Varnish($servers, 'my-cool-app.com');
 
+Again, if you access your web application on a port other than 80, make sure to
+include that port in the base URL::
+
+    $varnish = new Varnish($servers, 'my-cool-app.com:8080');
+
 .. note::
 
     To use the client, you need to :doc:`configure Varnish <varnish-configuration>` accordingly.


### PR DESCRIPTION
This is needed when websites are accessed on a port other than 80. Though this precisely resembles
suffixing port numbers on Varnish IP addresses, making it explicit will prevent confusion.
