### PR TITLE
[WIP] testing guzzle exceptions

### DIFF
--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -18,7 +18,7 @@ use FOS\HttpCache\Exception\ProxyUnreachableException;
 use Guzzle\Http\Client;
 use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Exception\CurlException;
-use Guzzle\Http\Exception\MultiTransferException;
+use Guzzle\Common\Exception\ExceptionCollection as GuzzleExceptionCollection;
 use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Message\RequestInterface;
 
@@ -173,7 +173,7 @@ abstract class AbstractProxyClient implements ProxyClientInterface
 
         try {
             $this->client->send($allRequests);
-        } catch (MultiTransferException $e) {
+        } catch (GuzzleExceptionCollection $e) {
             $this->handleException($e);
         }
     }
@@ -181,11 +181,11 @@ abstract class AbstractProxyClient implements ProxyClientInterface
     /**
      * Handle request exception
      *
-     * @param MultiTransferException $exceptions
+     * @param GuzzleExceptionCollection $exceptions
      *
      * @throws ExceptionCollection
      */
-    protected function handleException(MultiTransferException $exceptions)
+    protected function handleException(GuzzleExceptionCollection $exceptions)
     {
         $collection = new ExceptionCollection();
 


### PR DESCRIPTION
i tried to trigger the guzzle exception handling we have. [code coverage](https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSHttpCache/code-structure/master/class/FOS%5CHttpCache%5CProxyClient%5CAbstractProxyClient) indicates we never see a RequestException in the handleException method. however, i was not able to ever produce that exception. any ideas what we could do? or can we simply drop that excpetion? or am i just confused?

nevermind the code in this PR, i have left all kind of debugging and experimenting stuff lying around.
