### PR TITLE
Make install-nginx.sh Debian-compatible

### DIFF
--- a/tests/install-nginx.sh
+++ b/tests/install-nginx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sudo apt-get install build-essential libc6 libpcre3 libpcre3-dev libpcrecpp0 libssl0.9.8 libssl-dev zlib1g zlib1g-dev lsb-base
+sudo apt-get install build-essential libc6 libpcre3 libpcre3-dev libpcrecpp0 libssl-dev zlib1g zlib1g-dev lsb-base
 cd /tmp/
 mkdir custom_nginx
 cd custom_nginx


### PR DESCRIPTION
Try to remove libssl0.9.8 from packages, which is unavailable on Debian 7. With this package removed, the install-script.sh works fully on Debian. Let’s find out what happens on Travis.
