### PR TITLE
Add test case interface

### DIFF
--- a/src/Test/AbstractProxyClientTestCase.php
+++ b/src/Test/AbstractProxyClientTestCase.php
@@ -20,7 +20,7 @@ use Guzzle\Http\Message\Response;
  * Abstract caching proxy test case
  *
  */
-abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase implements ProxyTestCaseInterface
 {
     /**
      * A Guzzle HTTP client.
@@ -30,10 +30,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     protected $client;
 
     /**
-     * Assert a cache miss
-     *
-     * @param Response $response
-     * @param string   $message  Test failure message (optional)
+     * {@inheritdoc}
      */
     public function assertMiss(Response $response, $message = null)
     {
@@ -41,10 +38,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Assert a cache hit
-     *
-     * @param Response $response
-     * @param string   $message  Test failure message (optional)
+     * {@inheritdoc}
      */
     public function assertHit(Response $response, $message = null)
     {
@@ -62,13 +56,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Get HTTP response from your application
-     *
-     * @param string $url
-     * @param array  $headers
-     * @param array  $options
-     *
-     * @return Response
+     * {@inheritdoc}
      */
     public function getResponse($url, array $headers = array(), $options = array())
     {
@@ -76,9 +64,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Get HTTP client for your application
-     *
-     * @return Client
+     * {@inheritdoc}
      */
     public function getClient()
     {

--- a/src/Test/ProxyTestCaseInterface.php
+++ b/src/Test/ProxyTestCaseInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace FOS\HttpCache\Test;
+
+use Guzzle\Http\Message\Response;
+
+/**
+ * HTTP caching proxy test case
+ */
+interface ProxyTestCaseInterface
+{
+    /**
+     * Get HTTP test client that is configured for your caching proxy
+     *
+     * @return \Guzzle\Http\Client
+     */
+    public function getClient();
+
+    /**
+     * Get response through test client
+     *
+     * @param string $url
+     * @param array  $headers HTTP headers (optional)
+     * @param array  $options Request options (optional)
+     *
+     * @return \Guzzle\Http\Message\Response
+     */
+    public function getResponse($url, array $headers = array(), $options = array());
+
+    /**
+     * Assert a HTTP cache hit
+     *
+     * @param Response $response Guzzle response
+     * @param string   $message  Assertion failure message (optional)
+     *
+     * @throws \RuntimeException If cache header is not present
+     * @throws \PHPUnit_Framework_ExpectationFailedException If assertions fails
+     */
+    public function assertHit(Response $response, $message = null);
+
+    /**
+     * Assert a HTTP cache hit
+     *
+     * @param Response $response Guzzle response
+     * @param string   $message  Assertion failure message (optional)
+     *
+     * @throws \RuntimeException If cache header is not present
+     * @throws \PHPUnit_Framework_ExpectationFailedException If assertions fails
+     */
+    public function assertMiss(Response $response, $message = null);
+}


### PR DESCRIPTION
This interface will then also be implemented by the bundle base test class, at
least reducing the duplication in PHPDoc.
