### PR TITLE
Make Nginx cache dir optional

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,6 @@
 
     <php>
         <const name="NGINX_FILE" value="./tests/Functional/Fixtures/nginx/fos.conf" />
-        <const name="NGINX_CACHE_PATH" value="/tmp/fos_nginx_cache/" />
         <const name="WEB_SERVER_HOSTNAME" value="localhost" />
         <const name="WEB_SERVER_PORT" value="8080" />
         <const name="WEB_SERVER_DOCROOT" value="./tests/Functional/Fixtures/web" />

--- a/src/Test/NginxTestCase.php
+++ b/src/Test/NginxTestCase.php
@@ -82,15 +82,11 @@ abstract class NginxTestCase extends AbstractProxyClientTestCase
     }
 
     /**
-     * Get NGINX cache path
+     * Get Nginx cache directory
      */
     protected function getCacheDir()
     {
-        if (!defined('NGINX_CACHE_PATH')) {
-            throw new \Exception('Specify the NGINX_CACHE_PATH in phpunit.xml or override getCacheDir()');
-        }
-
-        return NGINX_CACHE_PATH;
+        return defined('NGINX_CACHE_PATH') ? NGINX_CACHE_PATH : null;
     }
 
     /**
@@ -100,6 +96,7 @@ abstract class NginxTestCase extends AbstractProxyClientTestCase
     {
         if (null === $this->proxy) {
             $this->proxy = new NginxProxy($this->getConfigFile());
+            $this->proxy->setPort($this->getCachingProxyPort());
 
             if ($this->getBinary()) {
                 $this->proxy->setBinary($this->getBinary());
@@ -107,10 +104,6 @@ abstract class NginxTestCase extends AbstractProxyClientTestCase
 
             if ($this->getCacheDir()) {
                 $this->proxy->setCacheDir($this->getCacheDir());
-            }
-
-            if ($this->getCachingProxyPort()) {
-                $this->proxy->setPort($this->getCachingProxyPort());
             }
         }
 
@@ -120,11 +113,11 @@ abstract class NginxTestCase extends AbstractProxyClientTestCase
     /**
      * Get proxy client
      *
-     * @param bool|string $purgeLocation Optional purgeLocation
+     * @param string $purgeLocation Optional purgeLocation
      *
-     * @return \FOS\HttpCache\ProxyClient\Nginx
+     * @return Nginx
      */
-    protected function getProxyClient($purgeLocation = false)
+    protected function getProxyClient($purgeLocation = '')
     {
         if (null === $this->proxyClient) {
             $this->proxyClient = new Nginx(

--- a/src/Test/Proxy/NginxProxy.php
+++ b/src/Test/Proxy/NginxProxy.php
@@ -19,9 +19,15 @@ class NginxProxy extends Abstractproxy
     protected $pid = '/tmp/foshttpcache-nginx.pid';
     protected $cacheDir;
 
+    /**
+     * Constructor
+     *
+     * @param string $configFile Path to Nginx configuration file
+     */
     public function __construct($configFile)
     {
         $this->setConfigFile($configFile);
+        $this->setCacheDir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'foshttpcache-nginx');
     }
 
     /**

--- a/src/Test/Proxy/VarnishProxy.php
+++ b/src/Test/Proxy/VarnishProxy.php
@@ -31,9 +31,8 @@ class VarnishProxy extends AbstractProxy
      */
     public function __construct($configFile)
     {
-        $this->cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'foshttpcache-test';
-
         $this->setConfigFile($configFile);
+        $this->setCacheDir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'foshttpcache-varnish');
     }
 
     /**

--- a/tests/Functional/Fixtures/nginx/fos.conf
+++ b/tests/Functional/Fixtures/nginx/fos.conf
@@ -14,7 +14,7 @@ http {
     error_log /tmp/fos_nginx_error.log debug;
     access_log /tmp/fos_nginx_access.log proxy_cache;
 
-    proxy_cache_path /tmp/fos_nginx_cache keys_zone=FOS_CACHE:10m;
+    proxy_cache_path /tmp/foshttpcache-nginx keys_zone=FOS_CACHE:10m;
 
     # Add an HTTP header with the cache status. Required for FOSHttpCache tests.
     add_header X-Cache $upstream_cache_status;


### PR DESCRIPTION
- Make Nginx resemble Varnish more closely by having a default cache temp dir
- Remove it from phpunit.xml.dist
- Also make $purgeLocation string to solve issue reported by Scrutinizer
