### PR TITLE
Make test naming more consistent with bundle

### DIFF
--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -19,7 +19,7 @@ By having your test classes extend ``VarnishTestCase``, you get:
 * ``$this->varnish`` referring to an instance of this library’s Varnish client
   that is configured to talk to your Varnish server
 * convenience methods for executing HTTP requests to your application:
-  ``$this->getClient()`` and ``$this->getResponse()``
+  ``$this->getHttpClient()`` and ``$this->getResponse()``
 * custom assertions ``assertHit`` and ``assertMiss`` for validating a cache hit/miss.
 
 Configuration

--- a/src/Test/NginxTestCase.php
+++ b/src/Test/NginxTestCase.php
@@ -32,7 +32,7 @@ use FOS\HttpCache\Test\Proxy\NginxProxy;
  * NGINX_FILE         NGINX configuration file (required if not passed to setUp)
  * NGINX_CACHE_PATH   NGINX configuration file (required if not passed to setUp)
  */
-abstract class NginxTestCase extends AbstractProxyClientTestCase
+abstract class NginxTestCase extends ProxyTestCase
 {
     /**
      * @var NginxProxy

--- a/src/Test/ProxyTestCase.php
+++ b/src/Test/ProxyTestCase.php
@@ -20,14 +20,14 @@ use Guzzle\Http\Message\Response;
  * Abstract caching proxy test case
  *
  */
-abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
+abstract class ProxyTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * A Guzzle HTTP client.
      *
      * @var Client
      */
-    protected $client;
+    protected $httpClient;
 
     /**
      * Assert a cache miss
@@ -72,7 +72,7 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
      */
     public function getResponse($url, array $headers = array(), $options = array())
     {
-        return $this->getClient()->get($url, $headers, $options)->send();
+        return $this->getHttpClient()->get($url, $headers, $options)->send();
     }
 
     /**
@@ -80,16 +80,16 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
      *
      * @return Client
      */
-    public function getClient()
+    public function getHttpClient()
     {
-        if (null === $this->client) {
-            $this->client = new Client(
+        if (null === $this->httpClient) {
+            $this->httpClient = new Client(
                 'http://' . $this->getHostName() . ':' . $this->getCachingProxyPort(),
                 array('curl.options' => array(CURLOPT_FORBID_REUSE => true))
             );
         }
 
-        return $this->client;
+        return $this->httpClient;
     }
 
     /**
@@ -125,12 +125,23 @@ abstract class AbstractProxyClientTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Get proxy server
+     *
      * @return \FOS\HttpCache\Test\Proxy\ProxyInterface
      */
     abstract protected function getProxy();
 
     /**
+     * Get proxy client
+     *
      * @return \FOS\HttpCache\ProxyClient\ProxyClientInterface
      */
     abstract protected function getProxyClient();
+
+    /**
+     * Get port that caching proxy listens on
+     *
+     * @return int
+     */
+    abstract protected function getCachingProxyPort();
 }

--- a/src/Test/VarnishTestCase.php
+++ b/src/Test/VarnishTestCase.php
@@ -13,7 +13,6 @@ namespace FOS\HttpCache\Test;
 
 use FOS\HttpCache\ProxyClient\Varnish;
 use FOS\HttpCache\Test\Proxy\VarnishProxy;
-use Symfony\Component\Process\Process;
 
 /**
  * A phpunit base class to write functional tests with varnish.
@@ -39,7 +38,7 @@ use Symfony\Component\Process\Process;
  *                      (default /tmp/foshttpcache-test)
  * WEB_SERVER_HOSTNAME  name of the webserver varnish has to talk to (required)
  */
-abstract class VarnishTestCase extends AbstractProxyClientTestCase
+abstract class VarnishTestCase extends ProxyTestCase
 {
     /**
      * @var Varnish

--- a/tests/Functional/Varnish/UserContextFailureTest.php
+++ b/tests/Functional/Varnish/UserContextFailureTest.php
@@ -78,7 +78,9 @@ class UserContextFailureTest extends VarnishTestCase
         $this->getResponse('/user_context.php', array(), array('cookies' => array('foo')));
 
         //Second request in head or post
-        $postResponse = $this->getClient()->post('/user_context.php', array(), null, array('cookies' => array('foo')))->send();
+        $postResponse = $this->getHttpClient()
+            ->post('/user_context.php', array(), null, array('cookies' => array('foo')))
+            ->send();
 
         $this->assertEquals('POST', $postResponse->getBody(true));
         $this->assertEquals('MISS', $postResponse->getHeader('X-HashCache'));

--- a/tests/Functional/Varnish/UserContextTestCase.php
+++ b/tests/Functional/Varnish/UserContextTestCase.php
@@ -47,13 +47,17 @@ abstract class UserContextTestCase extends VarnishTestCase
         $this->assertContextCache($cachedResponse2->getHeader('X-HashCache'));
         $this->assertHit($cachedResponse2);
 
-        $headResponse1 = $this->getClient()->head('/user_context.php', array(), array('cookies' => array('foo')))->send();
+        $headResponse1 = $this->getHttpClient()
+            ->head('/user_context.php', array(), array('cookies' => array('foo')))
+            ->send();
 
         $this->assertEquals('foo', $headResponse1->getHeader('X-HashTest'));
         $this->assertContextCache($headResponse1->getHeader('X-HashCache'));
         $this->assertHit($headResponse1);
 
-        $headResponse2 = $this->getClient()->head('/user_context.php', array(), array('cookies' => array('bar')))->send();
+        $headResponse2 = $this->getHttpClient()
+            ->head('/user_context.php', array(), array('cookies' => array('bar')))
+            ->send();
 
         $this->assertEquals('bar', $headResponse2->getHeader('X-HashTest'));
         $this->assertContextCache($headResponse2->getHeader('X-HashCache'));


### PR DESCRIPTION
- Rename getClient() to getHttpClient()
- Rename AbstractProxyClientTestCase to ProxyTestCase
