### PR TITLE
Fix Host header for proxy client requests

### DIFF
--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -161,11 +161,16 @@ abstract class AbstractProxyClient implements ProxyClientInterface
         $allRequests = array();
 
         foreach ($requests as $request) {
+            $headers = $request->getHeaders()->toArray();
+            // Force to re-create Host header if empty, as Apache chokes on this. See #128 for discussion.
+            if (empty($headers['Host'])) {
+                unset( $headers['Host'] );
+            }
             foreach ($this->servers as $server) {
                 $proxyRequest = $this->client->createRequest(
                     $request->getMethod(),
                     $server . $request->getResource(),
-                    $request->getHeaders()
+                    $headers
                 );
                 $allRequests[] = $proxyRequest;
             }

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -47,6 +47,23 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fos.lo', $headers->get('Host'));
     }
 
+    public function testBanEverythingNoBaseUrl()
+    {
+        $varnish = new Varnish(array('http://127.0.0.1:123'), null, $this->client);
+        $varnish->ban(array())->flush();
+
+        $requests = $this->getRequests();
+        $this->assertCount(1, $requests);
+        $this->assertEquals('BAN', $requests[0]->getMethod());
+
+        $headers = $requests[0]->getHeaders();
+        $this->assertEquals('.*', $headers->get('X-Host'));
+        $this->assertEquals('.*', $headers->get('X-Url'));
+        $this->assertEquals('.*', $headers->get('X-Content-Type'));
+        // Ensure host header matches the Varnish server one.
+        $this->assertEquals(array('127.0.0.1:123'), $headers->get('Host')->toArray());
+    }
+
     public function testBanHeaders()
     {
         $varnish = new Varnish(array('http://127.0.0.1:123'), 'fos.lo', $this->client);


### PR DESCRIPTION
When using `ban` requests with Varnish proxy client, requests are queued and sent with `flush()`. Queued requests are registered without host, making Guzzle create an empty `Host` header.

When flushing, Guzzle request is re-created starting with the original one (so without host), with all registered headers. The problem is that the empty `Host` header is also copied, and thus not re-created by Guzzle with the server URL. In the backend, cURL sees it and takes it into account, overriding passed URL silently.

This causes requests with empty host being fired by Guzzle, which is kind of annoying :smiley:.

This patch ensures `Host` header is removed before sending the real request.
