### PR TITLE
fix accept header handling when client sends no accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+1.1.2
+-----
+
+* **2014-11-17** Fixed documentation for user context varnish configuration to also work when
+  client omits the `Accept` HTTP header.

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,0 +1,2 @@
+deny from all
+

--- a/tests/Functional/Fixtures/varnish-4/user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-4/user_context.vcl
@@ -16,10 +16,12 @@ sub vcl_recv {
         && (req.http.cookie || req.http.authorization)
         && (req.method == "GET" || req.method == "HEAD")
     ) {
-        set req.http.x-fos-original-url    = req.url;
-        set req.http.x-fos-original-accept = req.http.accept;
-
-        set req.http.accept            = "application/vnd.fos.user-context-hash";
+        set req.http.x-fos-original-url = req.url;
+        # Backup accept header, if set
+        if (req.http.accept) {
+            set req.http.x-fos-original-accept = req.http.accept;
+        }
+        set req.http.accept = "application/vnd.fos.user-context-hash";
 
         # A little hack for testing all scenarios. Choose one for your application.
         if ("failure" == req.http.x-cache-hash) {
@@ -40,11 +42,15 @@ sub vcl_recv {
     if (req.restarts > 0
         && req.http.accept == "application/vnd.fos.user-context-hash"
     ) {
-        set req.url         = req.http.x-fos-original-url;
-        set req.http.accept = req.http.x-fos-original-accept;
-
+        set req.url = req.http.x-fos-original-url;
         unset req.http.x-fos-original-url;
-        unset req.http.x-fos-original-accept;
+        if (req.http.x-fos-original-accept) {
+            set req.http.accept = req.http.x-fos-original-accept;
+            unset req.http.x-fos-original-accept;
+        } else {
+            # If accept header was not set in original request, remove the header here.
+            unset req.http.accept;
+        }
 
         # Force the lookup, the backend must tell not to cache or vary on the
         # user hash to properly separate cached data.

--- a/tests/Functional/Fixtures/web/user_context.php
+++ b/tests/Functional/Fixtures/web/user_context.php
@@ -11,6 +11,16 @@
 
 header('X-Cache-Debug: 1');
 
+if (isset($_GET['accept'])) {
+    if ($_GET['accept'] != $_SERVER['HTTP_ACCEPT']) {
+        header('HTTP/1.1 500 Wrong accept header "' . $_SERVER['HTTP_ACCEPT'] . '", expected "' . $_GET['accept'] . '"');
+        exit;
+    }
+} elseif (isset($_SERVER['HTTP_ACCEPT'])) {
+    header('HTTP/1.1 500 Expected no accept header ' . $_SERVER['HTTP_ACCEPT']);
+    exit;
+}
+
 if ('POST' == strtoupper($_SERVER['REQUEST_METHOD'])) {
     echo "POST";
     exit;

--- a/tests/Functional/Varnish/UserContextTestCase.php
+++ b/tests/Functional/Varnish/UserContextTestCase.php
@@ -27,6 +27,10 @@ abstract class UserContextTestCase extends VarnishTestCase
      */
     abstract protected function assertContextCache($hashCache);
 
+    /**
+     * Sending requests without an Accept: header so none should arrive at the
+     * backend for the actual request.
+     */
     public function testUserContextHash()
     {
         $response1 = $this->getResponse('/user_context.php', array(), array('cookies' => array('foo')));
@@ -62,6 +66,17 @@ abstract class UserContextTestCase extends VarnishTestCase
         $this->assertEquals('bar', $headResponse2->getHeader('X-HashTest'));
         $this->assertContextCache($headResponse2->getHeader('X-HashCache'));
         $this->assertHit($headResponse2);
+    }
+
+    public function testAcceptHeader()
+    {
+        $response1 = $this->getResponse(
+            '/user_context.php?accept=text/plain',
+            array('Accept' => 'text/plain'),
+            array('cookies' => array('foo'))
+        );
+        $this->assertEquals('foo', $response1->getBody(true));
+
     }
 
     public function testUserContextUnauthorized()


### PR DESCRIPTION
we discovered this in a rest api where a client was sending requests without accept headers. this is not good practice but allowed by the http spec. if the backend only has one type of answer, it usually works out.

we accidentally converted this into an existing Accept header with empty value, which by the HTTP spec means the client is not accepting any format. leading a spec-adherent backend with no other option than raising a 4xx error.
