### PR TITLE
use current class createRequest instead of client

### DIFF
--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -183,10 +183,10 @@ abstract class AbstractProxyClient implements ProxyClientInterface
             $headers = $request->getHeaders()->toArray();
             // Force to re-create Host header if empty, as Apache chokes on this. See #128 for discussion.
             if (empty($headers['Host'])) {
-                unset( $headers['Host'] );
+                unset($headers['Host']);
             }
             foreach ($this->servers as $server) {
-                $proxyRequest = $this->client->createRequest(
+                $proxyRequest = $this->createRequest(
                     $request->getMethod(),
                     $server . $request->getResource(),
                     $headers


### PR DESCRIPTION
Hello,

I have to override createRequest to pass an option to the $request : $request->getQuery()->useUrlEncode(false);

I did overload on createRequest in VarnishProxy, but in AbstractProxy the request is override by sendRequest and the option is gone.

Thierry
