### PR TITLE
add note that varnish discards body when doing hash lookup

### DIFF
--- a/tests/Functional/Fixtures/varnish-3/user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-3/user_context.vcl
@@ -10,6 +10,8 @@ sub vcl_recv {
     }
 
     # Lookup the context hash if there are credentials on the request
+    # Only do this for cacheable requests. Returning a hash lookup discards the request body.
+    # https://www.varnish-cache.org/trac/ticket/652
     if (req.restarts == 0
         && (req.http.cookie || req.http.authorization)
         && (req.request == "GET" || req.request == "HEAD")

--- a/tests/Functional/Fixtures/varnish-4/user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-4/user_context.vcl
@@ -12,6 +12,8 @@ sub vcl_recv {
     }
 
     # Lookup the context hash if there are credentials on the request
+    # Only do this for cacheable requests. Returning a hash lookup discards the request body.
+    # https://www.varnish-cache.org/trac/ticket/652
     if (req.restarts == 0
         && (req.http.cookie || req.http.authorization)
         && (req.method == "GET" || req.method == "HEAD")


### PR DESCRIPTION
Another thing we just found out in our project:

We were (ab)using the context in a situation where we have a varnish redirecting to other internal servers that have no authentication on their own. We did a hash context lookup for all requests to decide whether the user is allowed to go to that external service (with a specific url to that service, symfony is configured to check permissions on those paths for specific groups). This all works well for GET, but with POST we loose the body which made the concept pointless.

This file is also shown in the doc.

I am not totally sure if its too much details - but i think at this place people might have creative ideas and be glad to be warned that this would not work...
