### PR TITLE
Clean up debug docs

### DIFF
--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -71,7 +71,7 @@ Enable Assertions
 ~~~~~~~~~~~~~~~~~
 
 For the `assertHit` and `assertMiss` assertions to work, you should add a
-:ref:`custom X-Debug header <varnish_debugging>` to responses served
+:ref:`custom X-Cache header <varnish_debugging>` to responses served
 by your Varnish.
 
 Usage

--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -201,7 +201,9 @@ You can do this as
 Debugging
 ~~~~~~~~~
 
-Configure your Varnish to set a debug header that shows whether a cache hit or miss occurred:
+Configure your Varnish to set a custom header (`X-Cache`) that shows whether a 
+cache hit or miss occurred. This header will only be set if your application
+sends an `X-Cache-Debug` header.
 
 .. configuration-block::
 

--- a/tests/Functional/Fixtures/varnish-4/debug.vcl
+++ b/tests/Functional/Fixtures/varnish-4/debug.vcl
@@ -3,9 +3,11 @@ sub vcl_deliver {
     # In Varnish 4 the obj.hits counter behaviour has changed, so we use a
     # different method: if X-Varnish contains only 1 id, we have a miss, if it
     # contains more (and therefore a space), we have a hit.
-    if (resp.http.x-varnish ~ " ") {
-        set resp.http.x-cache = "HIT";
-    } else {
-        set resp.http.x-cache = "MISS";
+    if (resp.http.x-cache-debug) {
+        if (resp.http.x-varnish ~ " ") {
+            set resp.http.x-cache = "HIT";
+        } else {
+            set resp.http.x-cache = "MISS";
+        }
     }
 }


### PR DESCRIPTION
Our Varnish 3 and 4 VCLs differed in that the first set the `X-Cache` header conditionally and the latter did so always.