### PR TITLE
document x-cache header for nginx

### DIFF
--- a/doc/nginx-configuration.rst
+++ b/doc/nginx-configuration.rst
@@ -7,10 +7,10 @@ Below you will find detailed NGINX configuration recommendations for the
 features provided by this library. The examples are tested with NGINX version
 1.4.6.
 
-NGINX cache is a set of key/value pairs. The key is built with elements taken from the requests 
+NGINX cache is a set of key/value pairs. The key is built with elements taken from the requests
 (URI, cookies, http headers etc) as specified by `proxy_cache_key` directive.
 
-When we interact with the cache to purge/refresh entries we must send to NGINX a request which has 
+When we interact with the cache to purge/refresh entries we must send to NGINX a request which has
 the very same values, for the elements used for building the key, as the request that create the entry.
 In this way NGINX can build the correct key and apply the required operation to the entry.
 
@@ -20,8 +20,8 @@ you can use in the key see `this page from the official documentation <http://ng
 Purge
 ~~~~~
 
-NGINX does not support :term:`purge` functionality out of the box but you can easily add it with 
-`ngx_cache_purge <https://github.com/FRiCKLE/ngx_cache_purge>`_ module. You just need to compile 
+NGINX does not support :term:`purge` functionality out of the box but you can easily add it with
+`ngx_cache_purge <https://github.com/FRiCKLE/ngx_cache_purge>`_ module. You just need to compile
 NGINX from sources adding `ngx_cache_purge` with `--add-module`
 
 You can check the script :source:`install-nginx.sh <tests/install-nginx.sh>` to get an idea
@@ -50,3 +50,14 @@ so add a line like the following to your config:
     :language: nginx
     :lines: 44
 
+.. _nginx_debugging:
+
+Debugging
+~~~~~~~~~
+
+Configure your Nginx to set a custom header (`X-Cache`) that shows whether a
+cache hit or miss occurred:
+
+.. code-block:: none
+
+    add_header X-Cache $upstream_cache_status;

--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -74,7 +74,7 @@ Constant                Getter                    Default                       
 Enable Assertions
 '''''''''''''''''
 
-For the `assertHit` and `assertMiss` assertions to work, you should add a
+For the `assertHit` and `assertMiss` assertions to work, you need to add a
 :ref:`custom X-Cache header <varnish_debugging>` to responses served
 by your Varnish.
 
@@ -104,8 +104,9 @@ Constant                Getter                    Default                       
 Enable Assertions
 '''''''''''''''''
 
-For the `assertHit` and `assertMiss` assertions to work, you should add the HTTP
-header ``X-Cache`` to your responses
+For the `assertHit` and `assertMiss` assertions to work, you need to add a
+:ref:`custom X-Cache header <nginx_debugging>` to responses served
+by your Nginx.
 
 Usage
 -----

--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -130,7 +130,7 @@ to the ``recv`` and the ``deliver`` methods:
 .. sidebar:: Caching User Specific Content
 
     By default, Varnish does not check for cached data as soon as the request
-    has a ``Cookie`` or ``Authorization`` header, as per the `builtin VCL`_ 
+    has a ``Cookie`` or ``Authorization`` header, as per the `builtin VCL`_
     (for Varnish 3, see `default VCL`_). For the user context, you make Varnish
     cache even when there are credentials present.
 
@@ -201,9 +201,9 @@ You can do this as
 Debugging
 ~~~~~~~~~
 
-Configure your Varnish to set a custom header (`X-Cache`) that shows whether a 
+Configure your Varnish to set a custom header (`X-Cache`) that shows whether a
 cache hit or miss occurred. This header will only be set if your application
-sends an `X-Cache-Debug` header.
+sends an `X-Cache-Debug` header:
 
 .. configuration-block::
 


### PR DESCRIPTION
adding doc how to activate the X-Cache header with nginx.

@hpatoio if you happen to know how we could set the X-Cache header only if the backend sends an X-Cache-Debug header, like we do for varnish, then please tell and we can add that.