### PR TITLE
Separating the tag handler into its own class

### DIFF
--- a/doc/cache-invalidator.rst
+++ b/doc/cache-invalidator.rst
@@ -43,7 +43,7 @@ See below for the :ref:`flush() <flush>` method.
 Invalidate a URL::
 
     $cacheInvalidator->invalidatePath('http://www.example.com/users')->flush();
-    
+
 Invalidate a URL with added header(s)::
 
     $cacheInvalidator->invalidatePath(
@@ -123,52 +123,6 @@ default headers always present to simplify the cache configuration rules.
 To invalidate on a custom header ``X-My-Header``, you would do::
 
     $cacheInvalidator->invalidate(array('X-My-Header' => 'my-value'))->flush();
-
-.. _tags:
-
-Invalidating Tags
------------------
-
-.. note::
-
-    Make sure to :doc:`configure your proxy <proxy-configuration>` for tagging first.
-
-With tags you can group related representations so it becomes easier to
-invalidate them. You will have to make sure your web application adds the
-correct tags on all responses by setting the ``X-Cache-Tags`` header. The
-FOSHttpCacheBundle_ does this for you when you’re using Symfony.
-
-Assume you sent four responses:
-
-+------------+-------------------------+
-| Response:  | ``X-Cache-Tags`` header:|
-+============+=========================+
-| ``/one``   | ``tag-one``             |
-+------------+-------------------------+
-| ``/two``   | ``tag-two, group-a``    |
-+------------+-------------------------+
-| ``/three`` | ``tag-three, group-a``  |
-+------------+-------------------------+
-| ``/four``  | ``tag-four, group-b``   |
-+------------+-------------------------+
-
-You can now invalidate some URLs using tags::
-
-    $cacheInvalidator->invalidateTags(array('group-a', 'tag-four'))->flush();
-
-
-This will ban all requests having either the tag ``group-a`` /or/ ``tag-four``.
-In the above example, this will invalidate ``/two``, ``/three`` and ``/four``.
-Only ``/one`` will stay in the cache.
-
-.. _custom_tags_header:
-
-Custom Tags Header
-~~~~~~~~~~~~~~~~~~
-
-Tagging uses a custom HTTP header to identify tags. You can change the default
-header ``X-Cache-Tags`` by calling ``setTagsHeader()``. Make sure to reflect this
-change in your :doc:`caching proxy configuration <proxy-configuration>`.
 
 .. _flush:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ Contents:
     proxy-configuration
     proxy-clients
     cache-invalidator
+    invalidation-handlers
     user-context
 
     testing-your-application

--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -1,0 +1,76 @@
+Extra Invalidation Handlers
+===========================
+
+This library provides decorators that build on top of the ``CacheInvalidator``
+to simplify common operations.
+
+.. _tags:
+
+Tag Handler
+-----------
+
+The tag handler helps you to invalidate all cache entries that where marked
+with a specified tag. It works only with a ``CacheInvalidator`` that supports
+``CacheInvalidator::INVALIDATE``.
+
+Setup
+~~~~~
+
+.. note::
+
+    Make sure to :doc:`configure your proxy <proxy-configuration>` for tagging first.
+
+The tag handler is a decorator around the ``CacheInvalidator``. After
+:doc:`creating the invalidator <cache-invalidator>` with a proxy client
+that implements the ``BanInterface``, instantiate the ``TagHandler``::
+
+    use FOS\HttpCache\Handler\TagHandler;
+
+    // $cacheInvalidator already created as instance of FOS\HttpCache\CacheInvalidator
+    $tagHandler = new TagHandler($cacheInvalidator);
+
+Usage
+~~~~~
+
+With tags you can group related representations so it becomes easier to
+invalidate them. You will have to make sure your web application adds the
+correct tags on all responses by setting the ``X-Cache-Tags`` header. The
+FOSHttpCacheBundle_ does this for you when you’re using Symfony.
+
+Assume you sent four responses:
+
++------------+-------------------------+
+| Response:  | ``X-Cache-Tags`` header:|
++============+=========================+
+| ``/one``   | ``tag-one``             |
++------------+-------------------------+
+| ``/two``   | ``tag-two, group-a``    |
++------------+-------------------------+
+| ``/three`` | ``tag-three, group-a``  |
++------------+-------------------------+
+| ``/four``  | ``tag-four, group-b``   |
++------------+-------------------------+
+
+You can now invalidate some URLs using tags::
+
+    $tagHandler->invalidateTags(array('group-a', 'tag-four'))->flush();
+
+This will ban all requests having either the tag ``group-a`` /or/ ``tag-four``.
+In the above example, this will invalidate ``/two``, ``/three`` and ``/four``.
+Only ``/one`` will stay in the cache.
+
+.. _custom_tags_header:
+
+Custom Tags Header
+~~~~~~~~~~~~~~~~~~
+
+Tagging uses a custom HTTP header to identify tags. You can change the default
+header ``X-Cache-Tags`` in the constructor::
+
+    use FOS\HttpCache\Handler\TagHandler;
+
+    // $cacheInvalidator already created as instance of FOS\HttpCache\CacheInvalidator
+    $tagHandler = new TagHandler($cacheInvalidator, 'My-Cache-Header');
+
+Make sure to reflect this change in your
+:doc:`caching proxy configuration <proxy-configuration>`.

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Handler;
+
+use FOS\HttpCache\CacheInvalidator;
+use FOS\HttpCache\Exception\UnsupportedProxyOperationException;
+
+/**
+ * Handler for cache tagging.
+ *
+ * @author David de Boer <david@driebit.nl>
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class TagHandler
+{
+    /**
+     * @var CacheInvalidator
+     */
+    private $invalidator;
+
+    /**
+     * @var string
+     */
+    private $tagsHeader;
+
+    /**
+     * Constructor
+     *
+     * @param CacheInvalidator $invalidator The invalidator instance.
+     * @param string           $tagsHeader  Header to use for tags, defaults to X-Cache-Tags.
+     *
+     * @throws UnsupportedProxyOperationException If CacheInvalidator does not support invalidate requests
+     */
+    public function __construct(CacheInvalidator $invalidator, $tagsHeader = 'X-Cache-Tags')
+    {
+        if (!$invalidator->supports(CacheInvalidator::INVALIDATE)) {
+            throw UnsupportedProxyOperationException::cacheDoesNotImplement('BAN');
+        }
+        $this->invalidator = $invalidator;
+        $this->tagsHeader = $tagsHeader;
+    }
+
+    /**
+     * Invalidate cache entries that contain any of the specified tags in their
+     * tag header.
+     *
+     * @param array $tags Cache tags
+     *
+     * @return $this
+     */
+    public function invalidateTags(array $tags)
+    {
+        $tagExpression = sprintf('(%s)(,.+)?$', implode('|', array_map('preg_quote', $tags)));
+        $headers = array($this->tagsHeader => $tagExpression);
+        $this->invalidator->invalidate($headers);
+
+        return $this;
+    }
+}

--- a/tests/Unit/Handler/TagHandlerTest.php
+++ b/tests/Unit/Handler/TagHandlerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\Handler;
+
+use FOS\HttpCache\CacheInvalidator;
+use FOS\HttpCache\Handler\TagHandler;
+
+class TagHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvalidateTags()
+    {
+        $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
+            ->shouldReceive('invalidate')
+            ->with(array('X-Cache-Tags' => '(post\-1|posts)(,.+)?$'))
+            ->once()
+            ->shouldReceive('supports')
+            ->with(CacheInvalidator::INVALIDATE)
+            ->once()
+            ->andReturn(true)
+            ->getMock();
+
+        $tagHandler = new TagHandler($cacheInvalidator);
+        $tagHandler->invalidateTags(array('post-1', 'posts'));
+    }
+
+    public function testInvalidateTagsCustomHeader()
+    {
+        $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
+            ->shouldReceive('invalidate')
+            ->with(array('Custom-Tags' => '(post\-1)(,.+)?$'))
+            ->once()
+            ->shouldReceive('supports')
+            ->with(CacheInvalidator::INVALIDATE)
+            ->once()
+            ->andReturn(true)
+            ->getMock();
+
+        $tagHandler = new TagHandler($cacheInvalidator, 'Custom-Tags');
+        $tagHandler->invalidateTags(array('post-1'));
+    }
+
+    /**
+     * @expectedException \FOS\HttpCache\Exception\UnsupportedProxyOperationException
+     */
+    public function testInvalidateUnsupported()
+    {
+        $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
+            ->shouldReceive('supports')
+            ->with(CacheInvalidator::INVALIDATE)
+            ->once()
+            ->andReturn(false)
+            ->getMock();
+
+        new TagHandler($cacheInvalidator);
+    }
+}

--- a/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
+++ b/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
@@ -28,9 +28,9 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
     {
         $mock = $this
             ->getMockBuilder('\FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache')
-             ->setMethods( $mockedMethods )
-             ->disableOriginalConstructor()
-             ->getMock()
+            ->setMethods( $mockedMethods )
+            ->disableOriginalConstructor()
+            ->getMock()
         ;
 
         // Force setting options property since we can't use original constructor.


### PR DESCRIPTION
Following the discussions, i want to build a separate TagHandler. This will be even more useful for the bundle, when we add further tag logic: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/182

/cc @dantleech

* [x] Add tests for the TagHandler
* [x] Adjust documentation
* [x] Create issue for v2 to drop all deprecated stuff #163