### PR TITLE
Documentation spelling CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,14 @@ before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then ./tests/ci/install-apache-hhvm.sh; fi"
   # Install deps
   - composer update --dev --prefer-source
-  # Install Sphinx
-  - sudo apt-get install python-sphinx
+  # Install Sphinx and enchant
+  - sudo apt-get install python-sphinx enchant
   - sudo pip install -r doc/requirements.txt
 
 script:
   - phpunit --coverage-clover=coverage.clover
   - make -C doc SPHINXOPTS='-nW' html
+  - make -C doc spelling
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  spelling   generate a spelling report"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -151,3 +152,7 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+spelling:
+	$(SPHINXBUILD) -b spelling $(ALLSPHINXOPTS) $(BUILDDIR)/spelling
+	@echo "Spelling report generated in $(BUILDDIR)/spelling/output.txt"

--- a/doc/cache-invalidator.rst
+++ b/doc/cache-invalidator.rst
@@ -100,7 +100,7 @@ caching proxy::
 
     $cacheInvalidator->invalidateRegex('.*css$')->flush();
 
-To invalidate all .png files on host example.com::
+To invalidate all ``.png`` files on host example.com::
 
     $cacheInvalidator
         ->invalidateRegex('.*', 'image/png', array('example.com'))

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,16 @@ highlight_language = 'php'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.coverage', 'sphinx.ext.extlinks', 'sensio.sphinx.configurationblock']
+extensions = [
+    'sphinx.ext.coverage',
+    'sphinx.ext.extlinks',
+    'sensio.sphinx.configurationblock',
+    'sphinxcontrib.spelling'
+]
+
+# Spelling configuration
+spelling_lang='en_US'
+spelling_word_list_filename='spelling_word_list.txt'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -37,7 +37,7 @@ This library mainly consists of:
 * test classes that you can use for integration testing your application
   against a caching proxy.
 
-Measures have been taken to minimise the performance impact of sending
+Measures have been taken to minimize the performance impact of sending
 invalidation requests:
 
 * Requests are not sent immediately, but aggregated to be sent in parallel.

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -153,7 +153,7 @@ You can invalidate all URLs matching a regular expression by using the
 for the path to invalidate and an optional content type regular expression and
 list of application hostnames.
 
-For instance, to ban all .png files on all application hosts::
+For instance, to ban all ``.png`` files on all application hosts::
 
     $client->banPath('.*png$');
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,4 @@
 git+https://github.com/fabpot/sphinx-php.git
 sphinx-rtd-theme==0.1.6
+sphinxcontrib-spelling
+pyenchant

--- a/doc/spelling_word_list.txt
+++ b/doc/spelling_word_list.txt
@@ -1,0 +1,16 @@
+admin
+backend
+cacheable
+config
+css
+hostname
+hostnames
+http
+invalidator
+localhost
+nginx
+roundtrip
+symfony
+whitelisted
+paywall
+paywalls

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -165,7 +165,7 @@ Cleaning the Cookie Header
 
 By default, the UserContextSubscriber only sets the session cookie (according to
 the ``session_name_prefix`` option) in the requests to the backend. If you need
-a different behaviour, overwrite ``UserContextSubscriber::cleanupHashLookupRequest``
+a different behavior, overwrite ``UserContextSubscriber::cleanupHashLookupRequest``
 with your own logic.
 
 .. _HttpCache: http://symfony.com/doc/current/book/http_cache.html#symfony-reverse-proxy

--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -10,7 +10,7 @@ The FOSHttpCache library provides base test case classes to help you write
 functional tests. This may be helpful to test the way your application sets
 caching headers and invalidates cached content.
 
-By having your test classes extend one of the testCase classes, you get:
+By having your test classes extend one of the test case classes, you get:
 
 * independent tests: all previously cached content is removed in the tests
   ``setUp`` method. The way this is done depends on which reverse proxy you use;


### PR DESCRIPTION
Added spelling check for the documentation.

Note this is american english, i.e. `favorite` instead of `favourite`, `behavior` instead of `behaviour`, I believe this is the Symfony standard.