### PR TITLE
Add authentication support to user context subscriber

### DIFF
--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -118,9 +118,10 @@ User Context
 ~~~~~~~~~~~~
 
 To support :doc:`user context hashing <user-context>` you need to register the
-``UserContextSubscriber``. If the default settings are right for you, you don't
-need to do anything more. You can customize a number of options through the
-constructor:
+``UserContextSubscriber``. The user context is then automatically recognized
+based on session cookies or authorization headers. If the default settings are
+right for you, you don't need to do anything more. You can customize a number of
+options through the constructor:
 
 * **anonymous_hash**: Hash used for anonymous user. This is a performance
   optimization to not do a backend request for users that are not logged in.
@@ -159,6 +160,16 @@ constructor:
     Wrong session name will lead to unexpected results such as having the same
     user context hash for every users, or not having it cached at all, which
     hurts performance.
+
+.. note::
+
+    To use authorization headers for user context, you might have to add some server
+    configuration to make these headers available to PHP.
+
+    With Apache, you can do this for example in a ``.htaccess`` file:
+
+        RewriteEngine On
+        RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
 Cleaning the Cookie Header
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -130,7 +130,10 @@ class UserContextSubscriber implements EventSubscriberInterface
                 $hashLookupRequest->cookies->set($name, $value);
             }
         }
-        $hashLookupRequest->headers->set('Cookie', http_build_query($sessionIds, '', '; '));
+
+        if (count($sessionIds) > 0) {
+            $hashLookupRequest->headers->set('Cookie', http_build_query($sessionIds, '', '; '));
+        }
     }
 
     /**
@@ -180,6 +183,16 @@ class UserContextSubscriber implements EventSubscriberInterface
      */
     private function isAnonymous(Request $request)
     {
+        // You might have to enable rewriting of the Authorization header in your server config or .htaccess:
+        // RewriteEngine On
+        // RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+        if ($request->server->has('AUTHORIZATION') ||
+            $request->server->has('HTTP_AUTHORIZATION') ||
+            $request->server->has('PHP_AUTH_USER')
+        ) {
+            return false;
+        }
+
         foreach ($request->cookies as $name => $value) {
             if ($this->isSessionName($name)) {
                 return false;

--- a/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
+++ b/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
@@ -132,6 +132,9 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $cookieString = "PHPSESSID=$sessionId1; foo=bar; PHPSESSIDsdiuhsdf4535d4f=$sessionId2";
         $request = Request::create('/foo', 'GET', array(), $cookies, array(), array('Cookie' => $cookieString));
 
+        // Add a cookie which should not be available in the eventual hash request anymore
+        $request->cookies->set('foo', 'bar');
+
         $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], array(), array(), array(), $request->server->all());
         $hashRequest->attributes->set('internalRequest', true);
         $hashRequest->headers->set('Accept', $options['user_hash_accept_header']);
@@ -160,6 +163,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
                     $request->getMethod();
                     $request->getPathInfo();
                     $that->assertEquals($hashRequest, $request);
+                    $that->assertCount(2, $request->cookies->all());
 
                     return true;
                 }),
@@ -177,6 +181,56 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedContextHash, $request->headers->get($options['user_hash_header']));
     }
 
+    /**
+     * @dataProvider provideConfigOptions
+     */
+    public function testUserHashUserWithAuthorizationHeader($arg, $options)
+    {
+        $userContextSubscriber = new UserContextSubscriber($arg);
+
+        $request = Request::create('/foo', 'GET', array(), array(), array(), array('HTTP_AUTHORIZATION' => 'foo'));
+
+        // Add a cookie which should not be available in the eventual hash request anymore
+        $request->cookies->set('foo', 'bar');
+
+        $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], array(), array(), array(), $request->server->all());
+        $hashRequest->attributes->set('internalRequest', true);
+        $hashRequest->headers->set('Accept', $options['user_hash_accept_header']);
+
+        // Ensure request properties have been filled up.
+        $hashRequest->getPathInfo();
+        $hashRequest->getMethod();
+
+        $expectedContextHash = 'my_generated_hash';
+        $hashResponse = new Response();
+        $hashResponse->headers->set($options['user_hash_header'], $expectedContextHash );
+
+        $that = $this;
+        $this->kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->with(
+                $this->callback(function (Request $request) use ($that, $hashRequest) {
+                    // we need to call some methods to get the internal fields initialized
+                    $request->getMethod();
+                    $request->getPathInfo();
+                    $that->assertEquals($hashRequest, $request);
+                    $that->assertCount(0, $request->cookies->all());
+
+                    return true;
+                })
+            )
+            ->will($this->returnValue($hashResponse));
+
+        $event = new CacheEvent($this->kernel, $request);
+
+        $userContextSubscriber->preHandle($event);
+        $response = $event->getResponse();
+
+        $this->assertNull($response);
+        $this->assertTrue($request->headers->has($options['user_hash_header']));
+        $this->assertSame($expectedContextHash, $request->headers->get($options['user_hash_header']));
+    }
 
     /**
      * @expectedException \InvalidArgumentException


### PR DESCRIPTION
This is a draft for https://github.com/FriendsOfSymfony/FOSHttpCache/issues/147, feedback is welcome! Tests will be added once the approach is accepted (I am new to all this caching stuff).

---
*everything below is obsolete*

I added the functionality to determine whether a request is anonymous based on session, basic authentication or oAuth2.

In my Symfony2 app, to only use oAuth2, I would overwrite `getDefaultSubscribers` in my own cache class like this:

```php
class AppCache extends EventDispatchingHttpCache
{
    protected function getDefaultSubscribers()
    {
        $options = $this->getOptions();
        $subscribers = array();
        $defaultSubscribersOption = isset($options['fos_default_subscribers']) ? $options['fos_default_subscribers'] : self::SUBSCRIBER_ALL;
        if ($defaultSubscribersOption & self::SUBSCRIBER_USER_CONTEXT) {
            $subscribers[] = new UserContextSubscriber(array('authorization' => array('oauth2')));
        }

        return $subscribers;
    }
}
```