### PR TITLE
cleanup hash lookup request

### DIFF
--- a/doc/user-context.rst
+++ b/doc/user-context.rst
@@ -27,7 +27,7 @@ Caching on user context works as follows:
 2. The :term:`caching proxy`  receives the request. It sends a request
    (the *hash request*) with a special accept header
    (``application/vnd.fos.user-context-hash``) to a specific URL,
-   e.g., ``/user_context_hash.php``.
+   e.g., ``/_fos_user_context_hash``.
 3. The :term:`application` receives the hash request. The application knows the
    client’s user context (roles, permissions, etc.) and generates a hash based
    on that information. The application then returns a response containing that
@@ -96,7 +96,9 @@ Returning the User Context Hash
 -------------------------------
 
 It is up to you to return the user context hash in response to the hash request
-(``/user_context_hash.php`` in step 3 above)::
+(``/_fos_user_context_hash`` in step 3 above)::
+
+    // <web-root>/_fos_user_context_hash/index.php
 
     $hash = $hashGenerator->generateHash();
 

--- a/tests/Functional/Fixtures/varnish-3/user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-3/user_context.vcl
@@ -24,7 +24,7 @@ sub vcl_recv {
 
         # Backup original URL
         set req.http.X-Fos-Original-Url = req.url;
-        set req.url = "/user_context_hash.php";
+        set req.url = "/_fos_user_context_hash";
 
         # For functional tests
         call user_context_hash_url;

--- a/tests/Functional/Fixtures/varnish-4/user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-4/user_context.vcl
@@ -26,7 +26,7 @@ sub vcl_recv {
 
         # Backup original URL
         set req.http.X-Fos-Original-Url = req.url;
-        set req.url = "/user_context_hash.php";
+        set req.url = "/_fos_user_context_hash";
 
         # For functional tests
         call user_context_hash_url;


### PR DESCRIPTION
fix #165 

/_fos_user_context_hash is the only default that involves no BC break. the Symfony cache is using this url by default.