### PR TITLE
addTags on TagHandler

### DIFF
--- a/doc/_static/fos.css
+++ b/doc/_static/fos.css
@@ -1,0 +1,3 @@
+.versionmodified {
+    font-weight: bold;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,6 +132,7 @@ html_static_path = ['_static']
 def setup(app):
     app.add_javascript('tabs.js')
     app.add_stylesheet('tabs.css')
+    app.add_stylesheet('fos.css')
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -9,9 +9,15 @@ to simplify common operations.
 Tag Handler
 -----------
 
-The tag handler helps you to invalidate all cache entries that where marked
-with a specified tag. It works only with a ``CacheInvalidator`` that supports
-``CacheInvalidator::INVALIDATE``.
+.. versionadded:: 1.3
+
+    The tag handler was added in FOSHttpCache 1.3. If you are using an older
+    version of the library and can not update, you need to use
+    ``CacheInvalidator::invalidateTags``.
+
+The tag handler helps you to mark responses with tags that you can later use to
+invalidate all cache entries with that tag. Tag invalidation works only with a
+``CacheInvalidator`` that supports ``CacheInvalidator::INVALIDATE``.
 
 Setup
 ~~~~~
@@ -34,8 +40,22 @@ Usage
 
 With tags you can group related representations so it becomes easier to
 invalidate them. You will have to make sure your web application adds the
-correct tags on all responses by setting the ``X-Cache-Tags`` header. The
-FOSHttpCacheBundle_ does this for you when you’re using Symfony.
+correct tags on all responses. You can add tags to the handler using::
+
+    $tagHandler->addTags(array('tag-two', 'group-a'));
+
+Before any content is sent out, you need to send the tag header_::
+
+    header(sprintf('%s: %s),
+        $tagHandler->getTagsHeaderName(),
+        $tagHandler->getTagsHeaderValue()
+    );
+
+.. tip::
+
+    If you are using Symfony with the FOSHttpCacheBundle_, the tag header is
+    set automatically. You also have `additional methods of defining tags`_ with
+    annotations and on URL patterns.
 
 Assume you sent four responses:
 
@@ -74,3 +94,6 @@ header ``X-Cache-Tags`` in the constructor::
 
 Make sure to reflect this change in your
 :doc:`caching proxy configuration <proxy-configuration>`.
+
+.. _header: http://php.net/header
+.. _additional methods of defining tags: http://foshttpcachebundle.readthedocs.org/en/latest/features/tagging.html

--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -45,7 +45,7 @@ correct tags on all responses. You can add tags to the handler using::
 
 Before any content is sent out, you need to send the tag header_::
 
-    header(sprintf('%s: %s),
+    header(sprintf('%s: %s'),
         $tagHandler->getTagsHeaderName(),
         $tagHandler->getTagsHeaderValue()
     );

--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -10,7 +10,6 @@ Tag Handler
 -----------
 
 .. versionadded:: 1.3
-
     The tag handler was added in FOSHttpCache 1.3. If you are using an older
     version of the library and can not update, you need to use
     ``CacheInvalidator::invalidateTags``.

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -160,7 +160,7 @@ class CacheInvalidator
      */
     public function setTagsHeader($tagsHeader)
     {
-        if ($this->tagHandler && $this->tagsHeader !== $tagsHeader) {
+        if ($this->tagHandler && $this->tagHandler->getTagsHeaderName() !== $tagsHeader) {
             $this->tagHandler = new TagHandler($this, $tagsHeader);
         }
 
@@ -172,11 +172,11 @@ class CacheInvalidator
      *
      * @return string
      *
-     * @deprecated Use TagHandler::getTagsHeader instead.
+     * @deprecated Use TagHandler::getTagsHeaderName instead.
      */
     public function getTagsHeader()
     {
-        return $this->tagsHeader;
+        return $this->tagHandler ? $this->tagHandler->getTagsHeaderName() : $this->tagsHeader;
     }
 
     /**


### PR DESCRIPTION
follow up of #162

This allows TagHandler to track tags. I tried adding a flush method that calls `header()` but feel there is little value to that. See the doc diff for how i propose to use this outside symfony.