### PR TITLE
do not expose cache tags to the internet

### DIFF
--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -99,12 +99,12 @@ Add the following to your Varnish configuration to enable :ref:`cache tagging <t
 
     .. literalinclude:: ../tests/Functional/Fixtures/varnish-4/ban.vcl
         :language: varnish4
-        :emphasize-lines: 8-13
+        :emphasize-lines: 8-13,39
         :linenos:
 
     .. literalinclude:: ../tests/Functional/Fixtures/varnish-3/ban.vcl
         :language: varnish3
-        :emphasize-lines: 8-13
+        :emphasize-lines: 8-13,39
         :linenos:
 
 .. _varnish user context:

--- a/tests/Functional/Fixtures/varnish-3/ban.vcl
+++ b/tests/Functional/Fixtures/varnish-3/ban.vcl
@@ -36,5 +36,6 @@ sub vcl_deliver {
         # Remove ban-lurker friendly custom headers when delivering to client
         unset resp.http.X-Url;
         unset resp.http.X-Host;
+        unset resp.http.X-Cache-Tags;
     }
 }

--- a/tests/Functional/Fixtures/varnish-4/ban.vcl
+++ b/tests/Functional/Fixtures/varnish-4/ban.vcl
@@ -35,5 +35,6 @@ sub vcl_deliver {
         # Remove ban-lurker friendly custom headers when delivering to client
         unset resp.http.X-Url;
         unset resp.http.X-Host;
+        unset resp.http.X-Cache-Tags;
     }
 }


### PR DESCRIPTION
we missed this, leading to showing cache tags to the internet. this is no security risk, but not elegant.