### PR TITLE
Fix Guzzle requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "guzzle/http": "3.*",
+        "guzzle/guzzle": "~3.0",
         "symfony/event-dispatcher": "~2.3",
         "symfony/options-resolver": "~2.3"
     },


### PR DESCRIPTION
`guzzle/http` is abandoned. This PR use the new Composer package `guzzle/guzzle`. It avoid the following errors when installing the bundle:


> Package guzzle/common is abandoned, you should avoid using it. Use guzzle/guzzle instead.
> Package guzzle/stream is abandoned, you should avoid using it. Use guzzle/guzzle instead.
> Package guzzle/parser is abandoned, you should avoid using it. Use guzzle/guzzle instead.
> Package guzzle/http is abandoned, you should avoid using it. Use guzzle/guzzle instead.

fix #176