### PR TITLE
need a way to access the TagHandler to refactor CacheManager in a BC way

### DIFF
--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -59,9 +59,12 @@ class CacheInvalidator
     private $eventDispatcher;
 
     /**
+     * @deprecated This reference is only for BC and will be removed in version 2.0. Do not add
+     * methods to interact with the TagHandler but promote to use the TagHandler directly.
+     *
      * @var TagHandler
      */
-    private $tagHandler;
+    protected $tagHandler;
 
     /**
      * @var string
@@ -115,6 +118,8 @@ class CacheInvalidator
      * @param EventDispatcherInterface $eventDispatcher
      *
      * @return $this
+     *
+     * @throws \Exception When trying to override the event dispatcher.
      */
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
     {

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -82,10 +82,14 @@ class TagHandler
      * This must be called before any response is sent to the client.
      *
      * @param array $tags List of tags to add.
+     *
+     * @return $this
      */
     public function addTags(array $tags)
     {
         $this->tags = array_merge($this->tags, $tags);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
the only alternative i can see is duplicating the TagHandler property in the CacheManager, but that feels horrible... still maybe that is the way to go? see also https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/182