### PR TITLE
Test user without credentials

### DIFF
--- a/tests/Functional/Fixtures/web/user_context_anon.php
+++ b/tests/Functional/Fixtures/web/user_context_anon.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+header('X-Cache-Debug: 1');
+
+header('Cache-Control: max-age=3600');
+header('Vary: X-User-Context-Hash');
+
+if (!isset($_COOKIE[0])) {
+    header('X-HashTest: anonymous');
+    echo "anonymous";
+} elseif ($_COOKIE[0] == "foo") {
+    header('X-HashTest: foo');
+    echo "foo";
+} else {
+    header('X-HashTest: bar');
+    echo "bar";
+}

--- a/tests/Functional/Varnish/UserContextTestCase.php
+++ b/tests/Functional/Varnish/UserContextTestCase.php
@@ -68,6 +68,29 @@ abstract class UserContextTestCase extends VarnishTestCase
         $this->assertHit($headResponse2);
     }
 
+    /**
+     * Making sure that non-authenticated and authenticated cache are not mixed up.
+     */
+    public function testUserContextNoAuth()
+    {
+        $response1 = $this->getResponse('/user_context_anon.php');
+        $this->assertEquals('anonymous', $response1->getBody(true));
+        $this->assertEquals('MISS', $response1->getHeader('X-HashCache'));
+
+        $response1 = $this->getResponse('/user_context_anon.php', array(), array('cookies' => array('foo')));
+        $this->assertEquals('foo', $response1->getBody(true));
+        $this->assertEquals('MISS', $response1->getHeader('X-HashCache'));
+
+        $cachedResponse1 = $this->getResponse('/user_context_anon.php');
+        $this->assertEquals('anonymous', $cachedResponse1->getBody(true));
+        $this->assertHit($cachedResponse1);
+
+        $cachedResponse1 = $this->getResponse('/user_context_anon.php', array(), array('cookies' => array('foo')));
+        $this->assertEquals('foo', $cachedResponse1->getBody(true));
+        $this->assertContextCache($cachedResponse1->getHeader('X-HashCache'));
+        $this->assertHit($cachedResponse1);
+    }
+
     public function testAcceptHeader()
     {
         $response1 = $this->getResponse(


### PR DESCRIPTION
I wanted to start with a failing test for the automatic hash and then realized that we don't need it at all. 

The hash request is only ever executed when there is a cookie / auth header: https://github.com/FriendsOfSymfony/FOSHttpCache/blob/master/tests/Functional/Fixtures/varnish-3/user_context.vcl#L16

The Vary information also includes the variant of not having the header in question.

I think we can close #132 and think whether we should remove the corresponding code in the SymfonyCache and just have no context header. https://github.com/FriendsOfSymfony/FOSHttpCache/blob/master/src/SymfonyCache/UserContextSubscriber.php#L165 - the backend certainly should not use the hash, but only Vary on it.