### PR TITLE
Exclude files and dirs when building packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+tests/ export-ignore


### PR DESCRIPTION
This will exclude some files and dirs when creating releases on GitHub. Smaller packages means faster downloads through Composer (using `--prefer-dist``) for our users. :wink: