### PR TITLE
Symfony HttpCache listener for custom ttl header

### DIFF
--- a/doc/includes/custom-ttl.rst
+++ b/doc/includes/custom-ttl.rst
@@ -1,0 +1,17 @@
+By default, the caching proxy looks at the ``s-maxage`` instruction in the
+``Cache-Control`` header to know for how long it should cache a page. But the
+``Cache-Control`` header is also sent to the client. Any caches on the Internet,
+for example the Internet provider or from a cooperate network might look at
+``s-maxage`` and cache the page. This can be a problem, notably when you do
+:doc:`explicit cache invalidation </cache-invalidator>`. In that
+scenario, you want your caching proxy to keep a page in cache for a long time,
+but caches outside your control must not keep the page for a long duration.
+
+One option could be to set a high ``s-maxage`` for the proxy and simply rewrite
+the response to remove or reduce the ``s-maxage``. This is not a good solution
+however, as you start to duplicate your caching rule definitions.
+
+The solution to this issue provided here is to use a separate, different header
+called ``X-Reverse-Proxy-TTL`` that controls the TTL of the caching proxy to
+keep ``s-maxage`` for other proxies. Because this is not a standard feature,
+you need to add configuration to your caching proxy.

--- a/doc/spelling_word_list.txt
+++ b/doc/spelling_word_list.txt
@@ -20,3 +20,4 @@ github
 vcl
 fos
 Vcl
+inline

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -43,7 +43,10 @@ the cache. Instead, overwrite the constructor of AppCache and register the
 subscribers there. A simple cache will look like this::
 
     use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
+    use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
+    use FOS\HttpCache\SymfonyCache\RefreshSubscriber;
     use FOS\HttpCache\SymfonyCache\UserContextSubscriber;
+    use FOS\HttpCache\SymfonyCache\CustomTtlListener();
 
     class AppCache extends EventDispatchingHttpCache
     {
@@ -54,9 +57,10 @@ subscribers there. A simple cache will look like this::
         {
             parent::__construct($kernel, $cacheDir);
 
-            $this->addSubscriber(new UserContextSubscriber());
             $this->addSubscriber(new PurgeSubscriber());
             $this->addSubscriber(new RefreshSubscriber());
+            $this->addSubscriber(new UserContextSubscriber());
+            $this->addSubscriber(new CustomTtlListener());
         }
     }
 
@@ -178,5 +182,18 @@ By default, the UserContextSubscriber only sets the session cookie (according to
 the ``session_name_prefix`` option) in the requests to the backend. If you need
 a different behavior, overwrite ``UserContextSubscriber::cleanupHashLookupRequest``
 with your own logic.
+
+Custom TTL
+~~~~~~~~~~
+
+.. include:: includes/custom-ttl.rst
+
+The ``CustomTtlSubscriber`` looks at a specific header to determine the TTL,
+preferring that over ``s-maxage``. The default header is ``X-Reverse-Proxy-TTL``
+but you can customize that in the subscriber constructor::
+
+    new CustomTtlSubscriber('My-TTL-Header');
+
+The custom header is removed before sending the response to the client.
 
 .. _HttpCache: http://symfony.com/doc/current/book/http_cache.html#symfony-reverse-proxy

--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -98,8 +98,10 @@ Make sure ``symfony/process`` is available in your project:
 
     $ composer require symfony/process
 
-Then set your Varnish configuration (VCL) file. All available configuration
-parameters are shown below.
+Then set your Varnish configuration (VCL) file. Configuration is handled either
+by overwriting the getter or by defining a PHP constant. You can set the
+constants in your ``phpunit.xml`` or in the bootstrap file. Available
+configuration parameters are:
 
 ======================= ========================= ================================================== ===========================================
 Constant                Getter                    Default                                            Description
@@ -109,9 +111,21 @@ Constant                Getter                    Default                       
 ``VARNISH_PORT``        ``getCachingProxyPort()`` ``6181``                                           port Varnish listens on
 ``VARNISH_MGMT_PORT``   ``getVarnishMgmtPort()``  ``6182``                                           Varnish management port
 ``VARNISH_CACHE_DIR``   ``getCacheDir()``         ``sys_get_temp_dir()`` + ``/foshttpcache-varnish`` directory to use for cache
-``VARNISH_VERSION``     ``getVarnishVersion()``   ``4``                                              installed varnish application version
 ``WEB_SERVER_HOSTNAME`` ``getHostName()``                                                            hostname your application can be reached at
 ======================= ========================= ================================================== ===========================================
+
+The Varnish version is controlled by an environment variable (in case you want
+to test both Varnish 3 and 4 on a continuous integration system). See the
+``.travis.yml`` of the FOSHttpCache git repository for an example.
+
+==================== ========================= ======= ===========================================
+Environment Variable Getter                    Default Description
+==================== ========================= ======= ===========================================
+``VARNISH_VERSION``  ``getVarnishVersion()``   ``4``   version of varnish application that is used
+==================== ========================= ======= ===========================================
+
+See ``tests/bootstrap.php`` for an example how this repository uses the version
+information to set the right ``VARNISH_FILE`` constant.
 
 Enable Assertions
 '''''''''''''''''

--- a/resources/config/varnish-3/fos_custom_ttl.vcl
+++ b/resources/config/varnish-3/fos_custom_ttl.vcl
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Read a custom TTL header for the time to live information, to be used
+ * instead of s-maxage.
+ */
+sub fos_custom_ttl_fetch {
+    if (beresp.http.X-Reverse-Proxy-TTL) {
+        /*
+         * Note that there is a ``beresp.ttl`` field in VCL but unfortunately
+         * it can only be set to absolute values and not dynamically. Thus we
+         * have to resort to an inline C code fragment.
+         */
+        C{
+            char *ttl;
+            ttl = VRT_GetHdr(sp, HDR_BERESP, "\024X-Reverse-Proxy-TTL:");
+            VRT_l_beresp_ttl(sp, atoi(ttl));
+        }C
+
+        unset beresp.http.X-Reverse-Proxy-TTL;
+    }
+}

--- a/resources/config/varnish-4/fos_custom_ttl.vcl
+++ b/resources/config/varnish-4/fos_custom_ttl.vcl
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+C{
+    #include <stdlib.h>
+}C
+
+/**
+ * Read a custom TTL header for the time to live information, to be used
+ * instead of s-maxage.
+ */
+sub fos_custom_ttl_backend_response {
+    if (beresp.http.X-Reverse-Proxy-TTL) {
+        /*
+         * Note that there is a ``beresp.ttl`` field in VCL but unfortunately
+         * it can only be set to absolute values and not dynamically. Thus we
+         * have to resort to an inline C code fragment.
+         *
+         * As of Varnish 4.0, inline C is disabled by default. To use this
+         * feature, you need to add `-p vcc_allow_inline_c=on` to your Varnish
+         * startup command.
+         */
+        C{
+            char *ttl;
+            const struct gethdr_s hdr = { HDR_BERESP, "\024X-Reverse-Proxy-TTL:" };
+            ttl = VRT_GetHdr(ctx, &hdr);
+            VRT_l_beresp_ttl(ctx, atoi(ttl));
+        }C
+
+        unset beresp.http.X-Reverse-Proxy-TTL;
+    }
+}

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -41,13 +41,15 @@ class CacheEvent extends Event
     /**
      * Make sure your $kernel implements CacheInvalidationInterface
      *
-     * @param CacheInvalidationInterface$kernel  The kernel raising with this event.
-     * @param Request                              $request The request being processed.
+     * @param CacheInvalidationInterface $kernel   The kernel raising with this event.
+     * @param Request                    $request  The request being processed.
+     * @param Response                   $response The response, if available
      */
-    public function __construct(CacheInvalidationInterface $kernel, Request $request)
+    public function __construct(CacheInvalidationInterface $kernel, Request $request, Response $response = null)
     {
         $this->kernel = $kernel;
         $this->request = $request;
+        $this->response = $response;
     }
 
     /**
@@ -71,6 +73,9 @@ class CacheEvent extends Event
     }
 
     /**
+     * Events that occur after the response is created provide the default response.
+     * Event listeners can also set the response to make it available here.
+     *
      * @return Response|null The response if one was set.
      */
     public function getResponse()

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace FOS\HttpCache\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\CacheEvent;
+use FOS\HttpCache\SymfonyCache\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Custom TTL handler for the symfony built-in HttpCache.
+ *
+ * This allows to use a custom header to control time to live in HttpCache and
+ * keep s-maxage for 3rd party proxies.
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+ *
+ * {@inheritdoc}
+ */
+class CustomTtlListener implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private $ttlHeader;
+
+    /**
+     * Header used for backing up the s-maxage
+     *
+     * @var string
+     */
+    const SMAXAGE_BACKUP = 'FOS-Smaxage-Backup';
+
+    /**
+     * @param string $ttlHeader The header that is used to specify the TTL header
+     */
+    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL')
+    {
+        $this->ttlHeader = $ttlHeader;
+    }
+
+    /**
+     * Use the TTL from the custom header rather than the default one.
+     *
+     * If there is such a header, the original s_maxage is backed up to the
+     * static::SMAXAGE_BACKUP header.
+     *
+     * @param CacheEvent $e
+     */
+    public function useCustomTtl(CacheEvent $e)
+    {
+        $response = $e->getResponse();
+        if (!$response->headers->has($this->ttlHeader)) {
+            return;
+        }
+        $backup = $response->headers->hasCacheControlDirective('s-maxage')
+            ? $response->headers->getCacheControlDirective('s-maxage')
+            : 'false'
+        ;
+        $response->headers->set(static::SMAXAGE_BACKUP, $backup);
+        $response->setTtl($response->headers->get($this->ttlHeader));
+    }
+
+    /**
+     * Remove the custom TTL header and restore s_maxage from the backup.
+     *
+     * @param CacheEvent $e
+     */
+    public function cleanResponse(CacheEvent $e)
+    {
+        $response = $e->getResponse();
+        if (!$response->headers->has($this->ttlHeader)
+            && !$response->headers->has(static::SMAXAGE_BACKUP)
+        ) {
+            return;
+        }
+
+        if ($response->headers->has(static::SMAXAGE_BACKUP)) {
+            $smaxage = $response->headers->get(static::SMAXAGE_BACKUP);
+            if ('false' === $smaxage) {
+                $response->headers->removeCacheControlDirective('s-maxage');
+            } else {
+                $response->headers->addCacheControlDirective('s-maxage', $smaxage);
+            }
+        }
+        $response->headers->remove($this->ttlHeader);
+        $response->headers->remove(static::SMAXAGE_BACKUP);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            Events::PRE_STORE => 'useCustomTtl',
+            Events::POST_HANDLE => 'cleanResponse',
+        );
+    }
+}

--- a/src/SymfonyCache/Events.php
+++ b/src/SymfonyCache/Events.php
@@ -17,5 +17,7 @@ namespace FOS\HttpCache\SymfonyCache;
 final class Events
 {
     const PRE_HANDLE = 'fos_http_cache.pre_handle';
+    const POST_HANDLE = 'fos_http_cache.post_handle';
     const PRE_INVALIDATE = 'fos_http_cache.pre_invalidate';
+    const PRE_STORE = 'fos_http_cache.pre_store';
 }

--- a/src/Test/Proxy/VarnishProxy.php
+++ b/src/Test/Proxy/VarnishProxy.php
@@ -23,6 +23,7 @@ class VarnishProxy extends AbstractProxy
     protected $configFile;
     protected $configDir;
     protected $cacheDir;
+    protected $allowInlineC = false;
 
     /**
      * Constructor
@@ -40,17 +41,21 @@ class VarnishProxy extends AbstractProxy
      */
     public function start()
     {
-        $this->runCommand(
-            $this->getBinary(),
-            [
-                '-a', $this->ip . ':' . $this->getPort(),
-                '-T', $this->ip . ':' . $this->getManagementPort(),
-                '-f', $this->getConfigFile(),
-                '-n', $this->getCacheDir(),
-                '-p', 'vcl_dir=' . $this->getConfigDir(),
-                '-P', $this->pid,
-            ]
-        );
+        $args = [
+            '-a', $this->ip . ':' . $this->getPort(),
+            '-T', $this->ip . ':' . $this->getManagementPort(),
+            '-f', $this->getConfigFile(),
+            '-n', $this->getCacheDir(),
+            '-p', 'vcl_dir=' . $this->getConfigDir(),
+
+            '-P', $this->pid,
+        ];
+        if ($this->getAllowInlineC()) {
+            $args[] = '-p';
+            $args[] = 'vcc_allow_inline_c=on';
+        }
+
+        $this->runCommand($this->getBinary(), $args);
 
         $this->waitFor($this->ip, $this->getPort(), 2000);
     }
@@ -138,5 +143,25 @@ class VarnishProxy extends AbstractProxy
     public function getCacheDir()
     {
         return $this->cacheDir;
+    }
+
+    /**
+     * Whether the inline C flag should be set.
+     *
+     * @return boolean
+     */
+    public function getAllowInlineC()
+    {
+        return $this->allowInlineC;
+    }
+
+    /**
+     * Set whether the inline c flag should be on or off
+     *
+     * @param boolean $allowInlineC True for on, false for off
+     */
+    public function setAllowInlineC($allowInlineC)
+    {
+        $this->allowInlineC = (boolean) $allowInlineC;
     }
 }

--- a/src/Test/VarnishTestCase.php
+++ b/src/Test/VarnishTestCase.php
@@ -35,8 +35,13 @@ use FOS\HttpCache\Test\Proxy\VarnishProxy;
  * VARNISH_MGMT_PORT    Varnish management port (default 6182)
  * VARNISH_CACHE_DIR    directory to use for cache
  *                      (default sys_get_temp_dir() + '/foshttpcache-varnish')
- * VARNISH_VERSION      Version of varnish: 3 or 4, defaults to 4.
  * WEB_SERVER_HOSTNAME  hostname/IP your application can be reached at (required)
+ *
+ * If you want to test with Varnish 3, you need to define an environment
+ * variable with the varnish version:
+ * <php>
+ *     <env name="VARNISH_VERSION" value="3" />
+ * </php>
  */
 abstract class VarnishTestCase extends ProxyTestCase
 {
@@ -113,7 +118,7 @@ abstract class VarnishTestCase extends ProxyTestCase
      */
     protected function getVarnishVersion()
     {
-        return getenv('VARNISH_VERSION') ?: 4;
+        return getenv('VARNISH_VERSION') ?: '4.0';
     }
 
     /**

--- a/tests/Functional/Fixtures/varnish-3/custom_ttl.vcl
+++ b/tests/Functional/Fixtures/varnish-3/custom_ttl.vcl
@@ -1,0 +1,14 @@
+include "../../../../resources/config/varnish-3/fos_debug.vcl";
+include "../../../../resources/config/varnish-3/fos_custom_ttl.vcl";
+
+backend default {
+    .host = "127.0.0.1";
+    .port = "8080";
+}
+sub vcl_fetch {
+    call fos_custom_ttl_fetch;
+}
+
+sub vcl_deliver {
+    call fos_debug_deliver;
+}

--- a/tests/Functional/Fixtures/varnish-3/fos.vcl
+++ b/tests/Functional/Fixtures/varnish-3/fos.vcl
@@ -2,6 +2,7 @@ include "../../../../resources/config/varnish-3/fos_debug.vcl";
 include "../../../../resources/config/varnish-3/fos_refresh.vcl";
 include "../../../../resources/config/varnish-3/fos_purge.vcl";
 include "../../../../resources/config/varnish-3/fos_ban.vcl";
+include "../../../../resources/config/varnish-3/fos_custom_ttl.vcl";
 
 backend default {
     .host = "127.0.0.1";
@@ -20,6 +21,7 @@ sub vcl_recv {
 
 sub vcl_fetch {
     call fos_ban_fetch;
+    call fos_custom_ttl_fetch;
 }
 
 sub vcl_hit {

--- a/tests/Functional/Fixtures/varnish-4/custom_ttl.vcl
+++ b/tests/Functional/Fixtures/varnish-4/custom_ttl.vcl
@@ -1,0 +1,17 @@
+vcl 4.0;
+
+include "../../../../resources/config/varnish-4/fos_debug.vcl";
+include "../../../../resources/config/varnish-4/fos_custom_ttl.vcl";
+
+backend default {
+    .host = "127.0.0.1";
+    .port = "8080";
+}
+
+sub vcl_deliver {
+    call fos_debug_deliver;
+}
+
+sub vcl_backend_response {
+    call fos_custom_ttl_backend_response;
+}

--- a/tests/Functional/Fixtures/web/custom-ttl.php
+++ b/tests/Functional/Fixtures/web/custom-ttl.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+header('Cache-Control: s-maxage=0');
+header('X-Reverse-Proxy-TTL: 3600');
+header('Content-Type: text/html');
+header('X-Cache-Debug: 1');
+
+echo microtime(true);

--- a/tests/Functional/Varnish/CustomTtlTest.php
+++ b/tests/Functional/Varnish/CustomTtlTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Functional\Varnish;
+
+use FOS\HttpCache\Test\VarnishTestCase;
+
+/**
+ * @group webserver
+ * @group varnish
+ */
+class CustomTtlTest extends VarnishTestCase
+{
+    public function setUp()
+    {
+        if ($this->getVarnishVersion() >= 4) {
+            $this->getProxy()->setAllowInlineC(true);
+        }
+        parent::setUp();
+    }
+
+    protected function getConfigFile()
+    {
+        switch ((int)$this->getVarnishVersion()) {
+            case 4:
+                return './tests/Functional/Fixtures/varnish-4/custom_ttl.vcl';
+            default:
+                return './tests/Functional/Fixtures/varnish-3/custom_ttl.vcl';
+        }
+    }
+
+    public function testCustomTtl()
+    {
+        $this->assertMiss($this->getResponse('/custom-ttl.php'));
+        $this->assertHit($this->getResponse('/custom-ttl.php'));
+    }
+}

--- a/tests/Functional/Varnish/UserContextCacheTest.php
+++ b/tests/Functional/Varnish/UserContextCacheTest.php
@@ -19,11 +19,11 @@ class UserContextCacheTest extends UserContextTestCase
 {
     protected function getConfigFile()
     {
-        switch ($this->getVarnishVersion()) {
-            case '4.0':
-                return './tests/Functional/Fixtures/varnish-4/user_context_cache.vcl';
-            default:
+        switch ((int)$this->getVarnishVersion()) {
+            case 3:
                 return './tests/Functional/Fixtures/varnish-3/user_context_cache.vcl';
+            default:
+                return './tests/Functional/Fixtures/varnish-4/user_context_cache.vcl';
         }
     }
 

--- a/tests/Functional/Varnish/UserContextFailureTest.php
+++ b/tests/Functional/Varnish/UserContextFailureTest.php
@@ -89,7 +89,7 @@ class UserContextFailureTest extends VarnishTestCase
 
     protected function getConfigFile()
     {
-        switch ($this->getVarnishVersion()) {
+        switch ((int)$this->getVarnishVersion()) {
             case 3:
                 return sprintf('./tests/Functional/Fixtures/varnish-3/user_context_%s.vcl', $this->mode);
             default:

--- a/tests/Functional/Varnish/UserContextNocacheTest.php
+++ b/tests/Functional/Varnish/UserContextNocacheTest.php
@@ -19,11 +19,11 @@ class UserContextNocacheTest extends UserContextTestCase
 {
     protected function getConfigFile()
     {
-        switch ($this->getVarnishVersion()) {
-            case '4.0':
-                return './tests/Functional/Fixtures/varnish-4/user_context_nocache.vcl';
-            default:
+        switch ((int)$this->getVarnishVersion()) {
+            case 3:
                 return './tests/Functional/Fixtures/varnish-3/user_context_nocache.vcl';
+            default:
+                return './tests/Functional/Fixtures/varnish-4/user_context_nocache.vcl';
         }
     }
 

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\CacheEvent;
+use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CustomTtlListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CacheInvalidationInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $kernel;
+
+    public function setUp()
+    {
+        $this->kernel = $this
+            ->getMockBuilder('FOS\HttpCache\SymfonyCache\CacheInvalidationInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    public function testCustomTtl()
+    {
+        $ttlListener = new CustomTtlListener();
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, array(
+            'X-Reverse-Proxy-TTL' => '120',
+            'Cache-Control' => 's-maxage=60, max-age=30',
+        ));
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->useCustomTtl($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        $this->assertSame('120', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertSame('60', $response->headers->get(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+
+    public function testCustomTtlNoSmaxage()
+    {
+        $ttlListener = new CustomTtlListener();
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, array(
+            'X-Reverse-Proxy-TTL' => '120',
+            'Cache-Control' => 'max-age=30',
+        ));
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->useCustomTtl($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        $this->assertSame('120', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertSame('false', $response->headers->get(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+
+    public function testCleanup()
+    {
+        $ttlListener = new CustomTtlListener();
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, array(
+            'X-Reverse-Proxy-TTL' => '120',
+            'Cache-Control' => 's-maxage=120, max-age=30',
+            CustomTtlListener::SMAXAGE_BACKUP => '60',
+        ));
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->cleanResponse($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        $this->assertTrue($response->headers->hasCacheControlDirective('s-maxage'));
+        $this->assertSame('60', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertFalse($response->headers->has('X-Reverse-Proxy-TTL'));
+        $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+
+    public function testCleanupNoSmaxage()
+    {
+        $ttlListener = new CustomTtlListener();
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, array(
+            'X-Reverse-Proxy-TTL' => '120',
+            'Cache-Control' => 's-maxage: 120, max-age: 30',
+            CustomTtlListener::SMAXAGE_BACKUP => 'false',
+        ));
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->cleanResponse($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        $this->assertFalse($response->headers->hasCacheControlDirective('s_maxage'));
+        $this->assertFalse($response->headers->has('X-Reverse-Proxy-TTL'));
+        $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,7 @@ if (!file_exists($file)) {
 
 if (!defined('VARNISH_FILE')) {
     if (getenv('VARNISH_VERSION')
-        && (0 === strncmp('3.', getenv('VARNISH_VERSION'), 2))
+        && (0 === strncmp('3', getenv('VARNISH_VERSION'), 1))
     ) {
         define('VARNISH_FILE', './tests/Functional/Fixtures/varnish-3/fos.vcl');
     } else {


### PR DESCRIPTION
fix #151

i guess its ok if this only goes to version 2, its not urgent but for completeness.

TODO
* [x] Document
* [x] Functional test

i opt for including this here rather than the bundle, for consistency of where we have http cache listeners. we could also move the vcl and documentation for the varnish custom ttl here - that would also make it easy to test that vcl as we already have the whole setup here.