### PR TITLE
Remove deprecations

### DIFF
--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -9,11 +9,6 @@ to simplify common operations.
 Tag Handler
 -----------
 
-.. versionadded:: 1.3
-    The tag handler was added in FOSHttpCache 1.3. If you are using an older
-    version of the library and can not update, you need to use
-    ``CacheInvalidator::invalidateTags``.
-
 The tag handler helps you to mark responses with tags that you can later use to
 invalidate all cache entries with that tag. Tag invalidation works only with a
 ``CacheInvalidator`` that supports ``CacheInvalidator::INVALIDATE``.

--- a/src/Exception/ExceptionCollection.php
+++ b/src/Exception/ExceptionCollection.php
@@ -17,9 +17,9 @@ namespace FOS\HttpCache\Exception;
  */
 class ExceptionCollection extends \Exception implements \IteratorAggregate, \Countable, HttpCacheExceptionInterface
 {
-    private $exceptions = array();
-    
-    public function __construct(array $exceptions = array())
+    private $exceptions = [];
+
+    public function __construct(array $exceptions = [])
     {
         foreach ($exceptions as $exception) {
             $this->add($exception);

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -35,7 +35,7 @@ class TagHandler
     /**
      * @var array
      */
-    private $tags = array();
+    private $tags = [];
 
     /**
      * Constructor
@@ -113,7 +113,7 @@ class TagHandler
     public function invalidateTags(array $tags)
     {
         $tagExpression = sprintf('(%s)(,.+)?$', implode('|', array_map('preg_quote', $this->escapeTags($tags))));
-        $headers = array($this->tagsHeader => $tagExpression);
+        $headers = [$this->tagsHeader => $tagExpression];
         $this->invalidator->invalidate($headers);
 
         return $this;
@@ -129,7 +129,7 @@ class TagHandler
     protected function escapeTags(array $tags)
     {
         array_walk($tags, function (&$tag) {
-            $tag = str_replace(array(',', "\n"), array('_', '_'), $tag);
+            $tag = str_replace([',', "\n"], ['_', '_'], $tag);
         });
 
         return $tags;

--- a/src/ProxyClient/Invalidation/BanInterface.php
+++ b/src/ProxyClient/Invalidation/BanInterface.php
@@ -46,7 +46,7 @@ interface BanInterface extends ProxyClientInterface
      *
      * The hosts parameter can either be a regular expression, e.g.
      * '^(www\.)?(this|that)\.com$' or an array of exact host names, e.g.
-     * array('example.com', 'other.net'). If the parameter is empty, all hosts
+     * ['example.com', 'other.net']. If the parameter is empty, all hosts
      * are matched.
 
      * @param string       $path        Regular expression pattern for URI to

--- a/src/ProxyClient/Invalidation/PurgeInterface.php
+++ b/src/ProxyClient/Invalidation/PurgeInterface.php
@@ -36,5 +36,5 @@ interface PurgeInterface extends ProxyClientInterface
      *
      * @return $this
      */
-    public function purge($url, array $headers = array());
+    public function purge($url, array $headers = []);
 }

--- a/src/ProxyClient/Invalidation/RefreshInterface.php
+++ b/src/ProxyClient/Invalidation/RefreshInterface.php
@@ -37,5 +37,5 @@ interface RefreshInterface extends ProxyClientInterface
      *
      * @return $this
      */
-    public function refresh($url, array $headers = array());
+    public function refresh($url, array $headers = []);
 }

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -62,7 +62,7 @@ class Symfony extends AbstractProxyClient implements PurgeInterface, RefreshInte
     /**
      * {@inheritdoc}
      */
-    public function purge($url, array $headers = array())
+    public function purge($url, array $headers = [])
     {
         $this->queueRequest($this->options['purge_method'], $url, $headers);
 
@@ -72,9 +72,9 @@ class Symfony extends AbstractProxyClient implements PurgeInterface, RefreshInte
     /**
      * {@inheritdoc}
      */
-    public function refresh($url, array $headers = array())
+    public function refresh($url, array $headers = [])
     {
-        $headers = array_merge($headers, array('Cache-Control' => 'no-cache'));
+        $headers = array_merge($headers, ['Cache-Control' => 'no-cache']);
         $this->queueRequest(self::HTTP_METHOD_REFRESH, $url, $headers);
 
         return $this;

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -39,17 +39,13 @@ class CacheEvent extends Event
     private $response;
 
     /**
-     * Make sure your $kernel implements CacheInvalidationInterface. Creating the event with other
-     * HttpCache classes is deprecated and will no longer be supported in version 2 of this library.
+     * Make sure your $kernel implements CacheInvalidationInterface
      *
-     * @param CacheInvalidationInterface|HttpCache $kernel  The kernel raising with this event.
+     * @param CacheInvalidationInterface$kernel  The kernel raising with this event.
      * @param Request                              $request The request being processed.
      */
-    public function __construct($kernel, Request $request)
+    public function __construct(CacheInvalidationInterface $kernel, Request $request)
     {
-        if (!($kernel instanceof CacheInvalidationInterface || $kernel instanceof HttpCache)) {
-            throw new \InvalidArgumentException('Expected a CacheInvalidationInterface or HttpCache');
-        }
         $this->kernel = $kernel;
         $this->request = $request;
     }

--- a/src/SymfonyCache/PurgeSubscriber.php
+++ b/src/SymfonyCache/PurgeSubscriber.php
@@ -34,7 +34,7 @@ class PurgeSubscriber extends AccessControlledSubscriber
      *
      * @var array
      */
-    private $options = array();
+    private $options = [];
 
     /**
      * When creating this subscriber, you can configure a number of options.
@@ -49,14 +49,14 @@ class PurgeSubscriber extends AccessControlledSubscriber
      *
      * @throws \InvalidArgumentException if unknown keys are found in $options
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [])
     {
         $resolver = new OptionsResolver();
         if (method_exists($resolver, 'setDefined')) {
             // this was only added in symfony 2.6
-            $resolver->setDefined(array('purge_client_matcher', 'purge_client_ips', 'purge_method'));
+            $resolver->setDefined(['purge_client_matcher', 'purge_client_ips', 'purge_method']);
         } else {
-            $resolver->setOptional(array('purge_client_matcher', 'purge_client_ips', 'purge_method'));
+            $resolver->setOptional(['purge_client_matcher', 'purge_client_ips', 'purge_method']);
         }
         $resolver->setDefaults(array(
             'purge_client_matcher' => null,

--- a/src/SymfonyCache/RefreshSubscriber.php
+++ b/src/SymfonyCache/RefreshSubscriber.php
@@ -42,7 +42,7 @@ class RefreshSubscriber extends AccessControlledSubscriber
      *
      * @throws \InvalidArgumentException if unknown keys are found in $options
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [])
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(

--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -56,7 +56,7 @@ class UserContextSubscriber implements EventSubscriberInterface
      *
      * @throws \InvalidArgumentException if unknown keys are found in $options
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [])
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
@@ -123,7 +123,7 @@ class UserContextSubscriber implements EventSubscriberInterface
      */
     protected function cleanupHashLookupRequest(Request $hashLookupRequest, Request $originalRequest)
     {
-        $sessionIds = array();
+        $sessionIds = [];
         foreach ($originalRequest->cookies as $name => $value) {
             if ($this->isSessionName($name)) {
                 $sessionIds[$name] = $value;
@@ -223,7 +223,7 @@ class UserContextSubscriber implements EventSubscriberInterface
      */
     private function generateHashLookupRequest(Request $request)
     {
-        $hashLookupRequest = Request::create($this->options['user_hash_uri'], $this->options['user_hash_method'], array(), array(), array(), $request->server->all());
+        $hashLookupRequest = Request::create($this->options['user_hash_uri'], $this->options['user_hash_method'], [], [], [], $request->server->all());
         $hashLookupRequest->attributes->set('internalRequest', true);
         $hashLookupRequest->headers->set('Accept', $this->options['user_hash_accept_header']);
         $this->cleanupHashLookupRequest($hashLookupRequest, $request);

--- a/src/Test/NginxTestCase.php
+++ b/src/Test/NginxTestCase.php
@@ -128,7 +128,7 @@ abstract class NginxTestCase extends ProxyTestCase
     {
         if (null === $this->proxyClient) {
             $this->proxyClient = new Nginx(
-                array('http://127.0.0.1:' . $this->getCachingProxyPort()),
+                ['http://127.0.0.1:' . $this->getCachingProxyPort()],
                 $this->getHostName()
             );
 

--- a/src/Test/Proxy/NginxProxy.php
+++ b/src/Test/Proxy/NginxProxy.php
@@ -52,7 +52,7 @@ class NginxProxy extends Abstractproxy
     public function stop()
     {
         if (file_exists($this->pid)) {
-            $this->runCommand('kill', array(file_get_contents($this->pid)));
+            $this->runCommand('kill', [file_get_contents($this->pid)]);
         }
     }
 
@@ -61,7 +61,7 @@ class NginxProxy extends Abstractproxy
      */
     public function clear()
     {
-        $this->runCommand('rm', array('-rf', $this->getCacheDir()));
+        $this->runCommand('rm', ['-rf', $this->getCacheDir()]);
         $this->start();
     }
 

--- a/src/Test/Proxy/VarnishProxy.php
+++ b/src/Test/Proxy/VarnishProxy.php
@@ -62,7 +62,7 @@ class VarnishProxy extends AbstractProxy
     {
         if (file_exists($this->pid)) {
             try {
-                $this->runCommand('kill', array('-9', file_get_contents($this->pid)));
+                $this->runCommand('kill', ['-9', file_get_contents($this->pid)]);
             } catch (\RuntimeException $e) {
                 // Ignore if command fails when Varnish wasn't running
             }

--- a/src/Test/SymfonyTestCase.php
+++ b/src/Test/SymfonyTestCase.php
@@ -84,10 +84,10 @@ abstract class SymfonyTestCase extends ProxyTestCase
     {
         if (null === $this->proxyClient) {
             $this->proxyClient = new Symfony(
-                array('http://127.0.0.1:' . $this->getCachingProxyPort()),
+                ['http://127.0.0.1:' . $this->getCachingProxyPort()],
                 $this->getHostName() . ':' . $this->getCachingProxyPort(),
                 null,
-                array('purge_method' => 'NOTIFY')
+                ['purge_method' => 'NOTIFY']
             );
         }
 

--- a/src/Test/VarnishTestCase.php
+++ b/src/Test/VarnishTestCase.php
@@ -152,7 +152,7 @@ abstract class VarnishTestCase extends ProxyTestCase
     {
         if (null === $this->proxyClient) {
             $this->proxyClient = new Varnish(
-                array('http://127.0.0.1:' . $this->getProxy()->getPort()),
+                ['http://127.0.0.1:' . $this->getProxy()->getPort()],
                 $this->getHostName() . ':' . $this->getProxy()->getPort()
             );
         }

--- a/src/UserContext/HashGenerator.php
+++ b/src/UserContext/HashGenerator.php
@@ -21,7 +21,7 @@ class HashGenerator
     /**
      * @var ContextProviderInterface[]
      */
-    private $providers = array();
+    private $providers = [];
 
     /**
      * Constructor

--- a/src/UserContext/UserContext.php
+++ b/src/UserContext/UserContext.php
@@ -20,7 +20,7 @@ namespace FOS\HttpCache\UserContext;
  */
 class UserContext implements \IteratorAggregate
 {
-    private $parameters = array();
+    private $parameters = [];
 
     /**
      * Set a parameter for this context

--- a/tests/Functional/CacheInvalidatorTest.php
+++ b/tests/Functional/CacheInvalidatorTest.php
@@ -28,23 +28,8 @@ class CacheInvalidatorTest extends VarnishTestCase
         $this->assertMiss($this->getResponse('/tags.php'));
         $this->assertHit($this->getResponse('/tags.php'));
 
-        $tagHandler->invalidateTags(array('tag1'));
+        $tagHandler->invalidateTags(['tag1']);
         $cacheInvalidator->flush();
-
-        $this->assertMiss($this->getResponse('/tags.php'));
-    }
-
-    /**
-     * Test the deprecated CacheInvalidator::invalidateTags method.
-     */
-    public function testInvalidateTagsBC()
-    {
-        $cacheInvalidator = new CacheInvalidator($this->getProxyClient());
-
-        $this->assertMiss($this->getResponse('/tags.php'));
-        $this->assertHit($this->getResponse('/tags.php'));
-
-        $cacheInvalidator->invalidateTags(array('tag1'))->flush();
 
         $this->assertMiss($this->getResponse('/tags.php'));
     }

--- a/tests/Functional/Fixtures/Symfony/AppKernel.php
+++ b/tests/Functional/Fixtures/Symfony/AppKernel.php
@@ -21,12 +21,12 @@ class AppKernel implements HttpKernelInterface
         switch ($request->getPathInfo()) {
             case '/cache':
                 $response = new Response(microtime(true));
-                $response->setCache(array('max_age' => 3600, 'public' => true));
+                $response->setCache(['max_age' => 3600, 'public' => true]);
 
                 return $response;
             case '/negotiation':
                 $response = new Response(microtime(true));
-                $response->setCache(array('max_age' => 3600, 'public' => true));
+                $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('Content-Type', $_SERVER['HTTP_ACCEPT']);
                 $response->setVary('Accept');
 

--- a/tests/Functional/Fixtures/web/symfony.php
+++ b/tests/Functional/Fixtures/web/symfony.php
@@ -14,8 +14,8 @@ $loader = require_once __DIR__.'/../../../../vendor/autoload.php';
 $symfonyProxy = new SymfonyProxy();
 
 $kernel = new AppKernel();
-$kernel = new AppCache($kernel, new Store($symfonyProxy->getCacheDir()), null, array('debug' => true));
-$kernel->addSubscriber(new PurgeSubscriber(array('purge_method' => 'NOTIFY')));
+$kernel = new AppCache($kernel, new Store($symfonyProxy->getCacheDir()), null, ['debug' => true]);
+$kernel->addSubscriber(new PurgeSubscriber(['purge_method' => 'NOTIFY']));
 $kernel->addSubscriber(new RefreshSubscriber());
 $kernel->addSubscriber(new UserContextSubscriber());
 $request = Request::createFromGlobals();

--- a/tests/Functional/SymfonyProxyClientTest.php
+++ b/tests/Functional/SymfonyProxyClientTest.php
@@ -31,8 +31,8 @@ class SymfonyProxyClientTest extends SymfonyTestCase
 
     public function testPurgeContentType()
     {
-        $json = array('Accept' => 'application/json');
-        $html = array('Accept' => 'text/html');
+        $json = ['Accept' => 'application/json'];
+        $html = ['Accept' => 'text/html'];
 
         $response = $this->getResponse('/symfony.php/negotiation', $json);
         $this->assertMiss($response);
@@ -52,7 +52,7 @@ class SymfonyProxyClientTest extends SymfonyTestCase
 
     public function testPurgeHost()
     {
-        $symfony = new Symfony(array('http://127.0.0.1:' . $this->getCachingProxyPort()), null, null, array('purge_method' => 'NOTIFY'));
+        $symfony = new Symfony(['http://127.0.0.1:' . $this->getCachingProxyPort()], null, null, ['purge_method' => 'NOTIFY']);
 
         $this->getResponse('/symfony.php/cache');
 
@@ -72,14 +72,14 @@ class SymfonyProxyClientTest extends SymfonyTestCase
 
         $originalTimestamp = (float)(string) $response->getBody();
         $refreshedTimestamp = (float)(string) $refreshed->getBody();
-        
+
         $this->assertGreaterThan($originalTimestamp, $refreshedTimestamp);
     }
 
     public function testRefreshContentType()
     {
-        $json = array('Accept' => 'application/json');
-        $html = array('Accept' => 'text/html');
+        $json = ['Accept' => 'application/json'];
+        $html = ['Accept' => 'text/html'];
 
         $this->getProxyClient()->refresh('/symfony.php/negotiation', $json)->flush();
 

--- a/tests/Functional/Varnish/VarnishProxyClientTest.php
+++ b/tests/Functional/Varnish/VarnishProxyClientTest.php
@@ -28,7 +28,7 @@ class VarnishProxyClientTest extends VarnishTestCase
         $this->assertMiss($this->getResponse('/json.php'));
         $this->assertHit($this->getResponse('/json.php'));
 
-        $this->getProxyClient()->ban(array(Varnish::HTTP_HEADER_URL => '.*'))->flush();
+        $this->getProxyClient()->ban([Varnish::HTTP_HEADER_URL => '.*'])->flush();
 
         $this->assertMiss($this->getResponse('/cache.php'));
         $this->assertMiss($this->getResponse('/json.php'));
@@ -39,10 +39,10 @@ class VarnishProxyClientTest extends VarnishTestCase
         $this->assertMiss($this->getResponse('/cache.php'));
         $this->assertHit($this->getResponse('/cache.php'));
 
-        $this->getProxyClient()->ban(array(Varnish::HTTP_HEADER_HOST => 'wrong-host.lo'))->flush();
+        $this->getProxyClient()->ban([Varnish::HTTP_HEADER_HOST => 'wrong-host.lo'])->flush();
         $this->assertHit($this->getResponse('/cache.php'));
 
-        $this->getProxyClient()->ban(array(Varnish::HTTP_HEADER_HOST => $this->getHostname()))->flush();
+        $this->getProxyClient()->ban([Varnish::HTTP_HEADER_HOST => $this->getHostname()])->flush();
         $this->assertMiss($this->getResponse('/cache.php'));
     }
 
@@ -83,8 +83,8 @@ class VarnishProxyClientTest extends VarnishTestCase
 
     public function testPurgeContentType()
     {
-        $json = array('Accept' => 'application/json');
-        $html = array('Accept' => 'text/html');
+        $json = ['Accept' => 'application/json'];
+        $html = ['Accept' => 'text/html'];
 
         $response = $this->getResponse('/negotation.php', $json);
         $this->assertMiss($response);
@@ -104,7 +104,7 @@ class VarnishProxyClientTest extends VarnishTestCase
 
     public function testPurgeHost()
     {
-        $varnish = new Varnish(array('http://127.0.0.1:' . $this->getProxy()->getPort()));
+        $varnish = new Varnish(['http://127.0.0.1:' . $this->getProxy()->getPort()]);
 
         $this->getResponse('/cache.php');
 
@@ -130,8 +130,8 @@ class VarnishProxyClientTest extends VarnishTestCase
 
     public function testRefreshContentType()
     {
-        $json = array('Accept' => 'application/json');
-        $html = array('Accept' => 'text/html');
+        $json = ['Accept' => 'application/json'];
+        $html = ['Accept' => 'text/html'];
 
         $this->getProxyClient()->refresh('/negotation.php', $json)->flush();
 

--- a/tests/Unit/Exception/ExceptionCollectionTest.php
+++ b/tests/Unit/Exception/ExceptionCollectionTest.php
@@ -31,10 +31,10 @@ class ExceptionCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($e1, $collection->getFirst());
 
-        $actual = array();
+        $actual = [];
         foreach ($collection as $e) {
             $actual[] = $e;
         }
-        $this->assertEquals(array($e1, $e2), $actual);
+        $this->assertEquals([$e1, $e2], $actual);
     }
 }

--- a/tests/Unit/Handler/TagHandlerTest.php
+++ b/tests/Unit/Handler/TagHandlerTest.php
@@ -20,7 +20,7 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
             ->shouldReceive('invalidate')
-            ->with(array('X-Cache-Tags' => '(post\-1|posts)(,.+)?$'))
+            ->with(['X-Cache-Tags' => '(post\-1|posts)(,.+)?$'])
             ->once()
             ->shouldReceive('supports')
             ->with(CacheInvalidator::INVALIDATE)
@@ -29,14 +29,14 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $tagHandler = new TagHandler($cacheInvalidator);
-        $tagHandler->invalidateTags(array('post-1', 'posts'));
+        $tagHandler->invalidateTags(['post-1', 'posts']);
     }
 
     public function testInvalidateTagsCustomHeader()
     {
         $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
             ->shouldReceive('invalidate')
-            ->with(array('Custom-Tags' => '(post\-1)(,.+)?$'))
+            ->with(['Custom-Tags' => '(post\-1)(,.+)?$'])
             ->once()
             ->shouldReceive('supports')
             ->with(CacheInvalidator::INVALIDATE)
@@ -46,14 +46,14 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
 
         $tagHandler = new TagHandler($cacheInvalidator, 'Custom-Tags');
         $this->assertEquals('Custom-Tags', $tagHandler->getTagsHeaderName());
-        $tagHandler->invalidateTags(array('post-1'));
+        $tagHandler->invalidateTags(['post-1']);
     }
 
     public function testEscapingTags()
     {
         $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
             ->shouldReceive('invalidate')
-            ->with(array('X-Cache-Tags' => '(post_test)(,.+)?$'))
+            ->with(['X-Cache-Tags' => '(post_test)(,.+)?$'])
             ->once()
             ->shouldReceive('supports')
             ->with(CacheInvalidator::INVALIDATE)
@@ -62,7 +62,7 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $tagHandler = new TagHandler($cacheInvalidator);
-        $tagHandler->invalidateTags(array('post,test'));
+        $tagHandler->invalidateTags(['post,test']);
     }
 
     /**
@@ -91,7 +91,7 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
 
         $tagHandler = new TagHandler($cacheInvalidator);
         $this->assertFalse($tagHandler->hasTags());
-        $tagHandler->addTags(array('post-1', 'test,post'));
+        $tagHandler->addTags(['post-1', 'test,post']);
         $this->assertTrue($tagHandler->hasTags());
         $this->assertEquals('post-1,test_post', $tagHandler->getTagsHeaderValue());
     }

--- a/tests/Unit/ProxyClient/AbstractProxyClientTest.php
+++ b/tests/Unit/ProxyClient/AbstractProxyClientTest.php
@@ -169,7 +169,7 @@ class AbstractProxyClientTest extends \PHPUnit_Framework_TestCase
 
     public function testFlushEmpty()
     {
-        $varnish = new Varnish(array('127.0.0.1', '127.0.0.2'), 'fos.lo', $this->client);
+        $varnish = new Varnish(['127.0.0.1', '127.0.0.2'], 'fos.lo', $this->client);
         $this->assertEquals(0, $varnish->flush());
 
         $this->assertCount(0, $this->client->getRequests());
@@ -228,13 +228,13 @@ class AbstractProxyClientTest extends \PHPUnit_Framework_TestCase
             ->andReturn([])
             ->getMock();
 
-        $varnish = new Varnish(array('127.0.0.1', '127.0.0.2'), 'fos.lo', $client);
+        $varnish = new Varnish(['127.0.0.1', '127.0.0.2'], 'fos.lo', $client);
 
         $this->assertEquals(
             2,
             $varnish
-                ->purge('/c', array('a' => 'b', 'c' => 'd'))
-                ->purge('/c', array('c' => 'd', 'a' => 'b')) // same request (header order is not significant)
+                ->purge('/c', ['a' => 'b', 'c' => 'd'])
+                ->purge('/c', ['c' => 'd', 'a' => 'b']) // same request (header order is not significant)
                 ->purge('/c') // different request as headers different
                 ->purge('/c')
                 ->flush()

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -37,18 +37,18 @@ class SymfonyTest extends \PHPUnit_Framework_TestCase
         $varnish = new Varnish($ips, 'my_hostname.dev', $this->client);
 
         $count = $varnish->purge('/url/one')
-            ->purge('/url/two', array('X-Foo' => 'bar'))
+            ->purge('/url/two', ['X-Foo' => 'bar'])
             ->flush()
         ;
         $this->assertEquals(2, $count);
-        
+
         $requests = $this->getRequests();
         $this->assertCount(4, $requests);
         foreach ($requests as $request) {
             $this->assertEquals('PURGE', $request->getMethod());
             $this->assertEquals('my_hostname.dev', $request->getHeaderLine('Host'));
         }
-    
+
         $this->assertEquals('http://127.0.0.1:8080/url/one', $requests[0]->getUri());
         $this->assertEquals('http://123.123.123.2/url/one', $requests[1]->getUri());
         $this->assertEquals('http://127.0.0.1:8080/url/two', $requests[2]->getUri());
@@ -59,7 +59,7 @@ class SymfonyTest extends \PHPUnit_Framework_TestCase
 
     public function testRefresh()
     {
-        $symfony = new Symfony(array('127.0.0.1:123'), 'fos.lo', $this->client);
+        $symfony = new Symfony(['127.0.0.1:123'], 'fos.lo', $this->client);
         $symfony->refresh('/fresh')->flush();
 
         $requests = $this->getRequests();
@@ -72,7 +72,7 @@ class SymfonyTest extends \PHPUnit_Framework_TestCase
     {
         $this->client = new MockHttpAdapter();
     }
-    
+
     /**
      * @return array|RequestInterface[]
      */

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -24,8 +24,8 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testBanEverything()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), 'fos.lo', $this->client);
-        $varnish->ban(array())->flush();
+        $varnish = new Varnish(['127.0.0.1:123'], 'fos.lo', $this->client);
+        $varnish->ban([])->flush();
 
         $requests = $this->getRequests();
         $this->assertCount(1, $requests);
@@ -39,8 +39,8 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testBanEverythingNoBaseUrl()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), null, $this->client);
-        $varnish->ban(array())->flush();
+        $varnish = new Varnish(['127.0.0.1:123'], null, $this->client);
+        $varnish->ban([])->flush();
 
         $requests = $this->getRequests();
         $this->assertCount(1, $requests);
@@ -49,19 +49,19 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Host'));
         $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Url'));
         $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Content-Type'));
-        
+
         // Ensure host header matches the Varnish server one.
         $this->assertEquals('http://127.0.0.1:123/', $requests[0]->getUri());
     }
 
     public function testBanHeaders()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), 'fos.lo', $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], 'fos.lo', $this->client);
         $varnish->setDefaultBanHeaders(
-            array('A' => 'B')
+            ['A' => 'B']
         );
         $varnish->setDefaultBanHeader('Test', '.*');
-        $varnish->ban(array())->flush();
+        $varnish->ban([])->flush();
 
         $requests = $this->getRequests();
         $this->assertCount(1, $requests);
@@ -74,9 +74,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testBanPath()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), 'fos.lo', $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], 'fos.lo', $this->client);
 
-        $hosts = array('fos.lo', 'fos2.lo');
+        $hosts = ['fos.lo', 'fos2.lo'];
         $varnish->banPath('/articles/.*', 'text/html', $hosts)->flush();
 
         $requests = $this->getRequests();
@@ -93,9 +93,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
      */
     public function testBanPathEmptyHost()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), 'fos.lo', $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], 'fos.lo', $this->client);
 
-        $hosts = array();
+        $hosts = [];
         $varnish->banPath('/articles/.*', 'text/html', $hosts);
     }
 
@@ -105,18 +105,18 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $varnish = new Varnish($ips, 'my_hostname.dev', $this->client);
 
         $count = $varnish->purge('/url/one')
-            ->purge('/url/two', array('X-Foo' => 'bar'))
+            ->purge('/url/two', ['X-Foo' => 'bar'])
             ->flush()
         ;
         $this->assertEquals(2, $count);
-        
+
         $requests = $this->getRequests();
         $this->assertCount(4, $requests);
         foreach ($requests as $request) {
             $this->assertEquals('PURGE', $request->getMethod());
             $this->assertEquals('my_hostname.dev', $request->getHeaderLine('Host'));
         }
-    
+
         $this->assertEquals('http://127.0.0.1:8080/url/one', $requests[0]->getUri());
         $this->assertEquals('http://123.123.123.2/url/one', $requests[1]->getUri());
         $this->assertEquals('http://127.0.0.1:8080/url/two', $requests[2]->getUri());
@@ -127,7 +127,7 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testRefresh()
     {
-        $varnish = new Varnish(array('127.0.0.1:123'), 'fos.lo', $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], 'fos.lo', $this->client);
         $varnish->refresh('/fresh')->flush();
 
         $requests = $this->getRequests();

--- a/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
+++ b/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
@@ -37,7 +37,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'debug' => false,
             'default_ttl' => 0,
-            'private_headers' => array( 'Authorization', 'Cookie' ),
+            'private_headers' => [ 'Authorization', 'Cookie' ],
             'allow_reload' => false,
             'allow_revalidate' => false,
             'stale_while_revalidate' => 2,
@@ -63,7 +63,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'GET');
         $response = new Response();
 
-        $httpCache = $this->getHttpCachePartialMock(array('lookup'));
+        $httpCache = $this->getHttpCachePartialMock(['lookup']);
         $subscriber = new TestSubscriber($this, $httpCache, $request);
         $httpCache->addSubscriber($subscriber);
         $httpCache
@@ -83,7 +83,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'GET');
         $response = new Response();
 
-        $httpCache = $this->getHttpCachePartialMock(array('lookup'));
+        $httpCache = $this->getHttpCachePartialMock(['lookup']);
         $subscriber = new TestSubscriber($this, $httpCache, $request);
         $subscriber->handleResponse = $response;
         $httpCache->addSubscriber($subscriber);
@@ -102,7 +102,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'GET');
         $response = new Response('', 500);
 
-        $httpCache = $this->getHttpCachePartialMock(array('pass'));
+        $httpCache = $this->getHttpCachePartialMock(['pass']);
         $subscriber = new TestSubscriber($this, $httpCache, $request);
         $httpCache->addSubscriber($subscriber);
         $httpCache
@@ -115,7 +115,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $method = $refHttpCache->getMethod('invalidate');
         $method->setAccessible(true);
 
-        $this->assertSame($response, $method->invokeArgs($httpCache, array($request, $catch)));
+        $this->assertSame($response, $method->invokeArgs($httpCache, [$request, $catch]));
         $this->assertEquals(1, $subscriber->invalidateHits);
     }
 
@@ -125,7 +125,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'GET');
         $response = new Response('', 400);
 
-        $httpCache = $this->getHttpCachePartialMock(array('pass'));
+        $httpCache = $this->getHttpCachePartialMock(['pass']);
         $subscriber = new TestSubscriber($this, $httpCache, $request);
         $subscriber->invalidateResponse = $response;
         $httpCache->addSubscriber($subscriber);
@@ -137,7 +137,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $method = $refHttpCache->getMethod('invalidate');
         $method->setAccessible(true);
 
-        $this->assertSame($response, $method->invokeArgs($httpCache, array($request, $catch)));
+        $this->assertSame($response, $method->invokeArgs($httpCache, [$request, $catch]));
         $this->assertEquals(1, $subscriber->invalidateHits);
     }
 }

--- a/tests/Unit/SymfonyCache/PurgeSubscriberTest.php
+++ b/tests/Unit/SymfonyCache/PurgeSubscriberTest.php
@@ -90,7 +90,7 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
         ;
 
         $matcher = new RequestMatcher('/forbidden');
-        $purgeSubscriber = new PurgeSubscriber(array('purge_client_matcher' => $matcher));
+        $purgeSubscriber = new PurgeSubscriber(['purge_client_matcher' => $matcher]);
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($this->kernel, $request);
 
@@ -107,7 +107,7 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('getStore')
         ;
 
-        $purgeSubscriber = new PurgeSubscriber(array('purge_client_ips' => '1.2.3.4'));
+        $purgeSubscriber = new PurgeSubscriber(['purge_client_ips' => '1.2.3.4']);
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($this->kernel, $request);
 
@@ -148,6 +148,6 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new PurgeSubscriber(array('purge_client_ip' => '1.2.3.4'));
+        new PurgeSubscriber(['purge_client_ip' => '1.2.3.4']);
     }
 }

--- a/tests/Unit/SymfonyCache/RefreshSubscriberTest.php
+++ b/tests/Unit/SymfonyCache/RefreshSubscriberTest.php
@@ -56,7 +56,7 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
         ;
 
         $matcher = new RequestMatcher('/forbidden');
-        $refreshSubscriber = new RefreshSubscriber(array('refresh_client_matcher' => $matcher));
+        $refreshSubscriber = new RefreshSubscriber(['refresh_client_matcher' => $matcher]);
         $request = Request::create('http://example.com/foo');
         $request->headers->addCacheControlDirective('no-cache');
         $event = new CacheEvent($this->kernel, $request);
@@ -72,7 +72,7 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('fetch')
         ;
 
-        $refreshSubscriber = new RefreshSubscriber(array('refresh_client_ips' => '1.2.3.4'));
+        $refreshSubscriber = new RefreshSubscriber(['refresh_client_ips' => '1.2.3.4']);
         $request = Request::create('http://example.com/foo');
         $request->headers->addCacheControlDirective('no-cache');
         $event = new CacheEvent($this->kernel, $request);
@@ -124,6 +124,6 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new RefreshSubscriber(array('purge_client_ip' => '1.2.3.4'));
+        new RefreshSubscriber(['purge_client_ip' => '1.2.3.4']);
     }
 }

--- a/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
+++ b/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
@@ -54,8 +54,8 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         );;
 
         return array(
-            array(array(), $options),
-            array($custom, $custom + $options)
+            [[], $options],
+            [$custom, $custom + $options]
         );
     }
 
@@ -130,9 +130,9 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
             'foo' => 'bar'
         );
         $cookieString = "PHPSESSID=$sessionId1; foo=bar; PHPSESSIDsdiuhsdf4535d4f=$sessionId2";
-        $request = Request::create('/foo', 'GET', array(), $cookies, array(), array('Cookie' => $cookieString));
+        $request = Request::create('/foo', 'GET', [], $cookies, [], ['Cookie' => $cookieString]);
 
-        $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], array(), array(), array(), $request->server->all());
+        $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], [], [], [], $request->server->all());
         $hashRequest->attributes->set('internalRequest', true);
         $hashRequest->headers->set('Accept', $options['user_hash_accept_header']);
         $hashRequest->headers->set('Cookie', "PHPSESSID=$sessionId1; PHPSESSIDsdiuhsdf4535d4f=$sessionId2");
@@ -146,7 +146,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         // Just avoid the response to modify the request object, otherwise it's impossible to test objects equality.
         /** @var \Symfony\Component\HttpFoundation\Response|\PHPUnit_Framework_MockObject_MockObject $hashResponse */
         $hashResponse = $this->getMockBuilder('\Symfony\Component\HttpFoundation\Response')
-            ->setMethods(array('prepare'))
+            ->setMethods(['prepare'])
             ->getMock();
         $hashResponse->headers->set($options['user_hash_header'], $expectedContextHash );
 
@@ -186,9 +186,9 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $userContextSubscriber = new UserContextSubscriber($arg);
 
         // The foo cookie should not be available in the eventual hash request anymore
-        $request = Request::create('/foo', 'GET', array(), array('foo' => 'bar'), array(), array('HTTP_AUTHORIZATION' => 'foo'));
+        $request = Request::create('/foo', 'GET', [], ['foo' => 'bar'], [], ['HTTP_AUTHORIZATION' => 'foo']);
 
-        $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], array(), array(), array(), $request->server->all());
+        $hashRequest = Request::create($options['user_hash_uri'], $options['user_hash_method'], [], [], [], $request->server->all());
         $hashRequest->attributes->set('internalRequest', true);
         $hashRequest->headers->set('Accept', $options['user_hash_accept_header']);
 
@@ -233,6 +233,6 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new UserContextSubscriber(array('foo' => 'bar'));
+        new UserContextSubscriber(['foo' => 'bar']);
     }
 }

--- a/tests/Unit/UserContext/HashGeneratorTest.php
+++ b/tests/Unit/UserContext/HashGeneratorTest.php
@@ -19,9 +19,9 @@ class HashGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testGenerateHash()
     {
-        $hashGenerator = new HashGenerator(array(new FooProvider()));
+        $hashGenerator = new HashGenerator([new FooProvider()]);
 
-        $expectedHash = hash('sha256', serialize(array('foo' => 'bar')));
+        $expectedHash = hash('sha256', serialize(['foo' => 'bar']));
 
         $this->assertEquals($expectedHash, $hashGenerator->generateHash());
     }
@@ -31,7 +31,7 @@ class HashGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorError()
     {
-        new HashGenerator(array());
+        new HashGenerator([]);
     }
 }
 

--- a/tests/Unit/UserContext/UserContextTest.php
+++ b/tests/Unit/UserContext/UserContextTest.php
@@ -33,7 +33,7 @@ class UserContextTest extends \PHPUnit_Framework_TestCase
 
         $userContext->addParameter('authenticated', true);
         $userContext->setParameters(array(
-            'roles' => array('ROLE_USER'),
+            'roles' => ['ROLE_USER'],
             'foo' => 'bar'
         ));
 
@@ -41,12 +41,12 @@ class UserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($userContext->hasParameter('foo'));
         $this->assertTrue($userContext->hasParameter('roles'));
 
-        $parameters = array();
+        $parameters = [];
         foreach ($userContext as $name => $value) {
             $parameters[$name] = $value;
         }
         $this->assertEquals(
-            array('roles' => array('ROLE_USER'), 'foo' => 'bar'),
+            ['roles' => array('ROLE_USER'), 'foo' => 'bar'],
             $parameters
         );
     }


### PR DESCRIPTION
* Remove deprecated methods
* Update docs
* Switch to PHP 5.4+ array syntax

Fix #163.