### PR TITLE
Update Documentation

### DIFF
--- a/doc/invalidation-handlers.rst
+++ b/doc/invalidation-handlers.rst
@@ -67,11 +67,16 @@ Assume you sent four responses:
 
 You can now invalidate some URLs using tags::
 
-    $tagHandler->invalidateTags(array('group-a', 'tag-four'))->flush();
+    $tagHandler->invalidateTags(array('group-a', 'tag-four'));
 
 This will ban all requests having either the tag ``group-a`` /or/ ``tag-four``.
 In the above example, this will invalidate ``/two``, ``/three`` and ``/four``.
 Only ``/one`` will stay in the cache.
+
+.. note::
+
+    Don't forget to :ref:`flush <flush>` these invalidation changes to the proxy
+    from the ``CacheInvalidator`` object towards the end of your application.
 
 .. _custom_tags_header:
 


### PR DESCRIPTION
Remove the call to flush() after invalidating tags from the tag handler, and add a note to explain why.
Fixes #221.