### PR TITLE
VCL: Removing max-age directives when using user context hash

### DIFF
--- a/resources/config/varnish-3/fos_user_context.vcl
+++ b/resources/config/varnish-3/fos_user_context.vcl
@@ -87,6 +87,16 @@ sub fos_user_context_deliver {
 
     # If we get here, this is a real response that gets sent to the client.
 
+    # Remove cache ttl directives.
+    # Subsequent Reverse proxies and clients from this point forward cannot Vary
+    # on user context hash and should not attempt to cache
+    if (resp.http.X-Cache-Debug) {
+        # For debug purposes, adds previous ttl to the response headers
+        set resp.http.X-Original-Cache-Control = resp.http.Cache-Control;
+    }
+
+    set resp.http.Cache-Control = "max-age=0, s-max-age=0, private";
+
     # Remove the vary on context user hash, this is nothing public. Keep all
     # other vary headers.
     set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");

--- a/resources/config/varnish-4/fos_user_context.vcl
+++ b/resources/config/varnish-4/fos_user_context.vcl
@@ -85,6 +85,16 @@ sub fos_user_context_deliver {
 
     # If we get here, this is a real response that gets sent to the client.
 
+    # Remove cache ttl directives.
+    # Subsequent Reverse proxies and clients from this point forward cannot Vary
+    # on user context hash and should not attempt to cache
+    if (resp.http.X-Cache-Debug) {
+        # For debug purposes, adds previous ttl to the response headers
+        set resp.http.X-Original-Cache-Control = resp.http.Cache-Control;
+    }
+
+    set resp.http.Cache-Control = "must-revalidate, no-cache, private";
+
     # Remove the vary on context user hash, this is nothing public. Keep all
     # other vary headers.
     set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");


### PR DESCRIPTION
We experienced a cache issue on a recent project using the User Context feature of the FOSHttpCache component.

In our use case, we use the User Context to contextualize cache according to the currency the user chooses to browse in. That is, default is we display price in USD, but you can choose to have them be displayed in EUR for example. That is stored in a cookie and we vary the cache by generating a different user hash for different currencies.

Problem was, when a user goes to a page, then changes currency, we refresh that page, and the currency switch does not work. Refreshing the page with F5 displays the correct, newly selected currency.

The reason is we set a max-age (in addition to s-max-age) on all our page Cache-Control header. The page having the same URL on every currency, the browser served content from its own cache without requesting the content from Varnish.

We hotfixed the issue by setting a max-age=0 on every cached action, but this made light to what I think is an issue with the component itself. There is no way a client, or a subsequent gateway, intervening after the initial gateway handling the user context hash, can properly cache a content subject to the User Context feature, because the Vary header and the hash itself is removed from the response.
In that case, I believe we should always override the response header and force a no-cache. Symfony HTTPCache component does this with ESI: if there are any ESI in a given page, it forces a no-cache, must-revalidate header for the same reasons.

Therefore I suggest the following changes to the Varnish configuration files:

```vcl
  sub fos_user_context_deliver {
    [...]
    # If we get here, this is a real response that gets sent to the client.

    # Remove cache ttl directives.
    # Subsequent Reverse proxies and clients from this point forward cannot Vary
    # on user context hash and should not attempt to cache
    if (resp.http.X-Cache-Debug) {
        # For debug purposes, adds previous ttl to the response headers
        set resp.http.X-Original-Cache-Control = resp.http.Cache-Control;
    }

    set resp.http.Cache-Control = "must-revalidate, no-cache, private";
    [...]
  }
```

The debug header is optionnal, I found it useful to make sure the initial cache directives are correct despite the override.
If I'm correct in this, the same override should be implemented with Symfony HTTPCache implementation. It's not part of this PR because I believe it should reside in the FOSHttpCacheBundle (and our use case was using Varnish).