### PR TITLE
Fix the upload of the code coverage to Scrutinizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   # Install NGINX
   - sh ./tests/install-nginx.sh
   # Starting webserver
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then ./tests/ci/install-apache-hhvm.sh; fi"
+  - if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ]; then ./tests/ci/install-apache-hhvm.sh; fi
 
 script:
   - phpunit --coverage-clover=coverage.clover
@@ -44,8 +44,10 @@ script:
   - make -C doc spelling
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  # avoid uploading the code coverage for PHP 7 and HHVM as they cannot generate it (PHPUnit dropped the old HHVM driver
+  # and the XDebug API is not implemented in HHVM 3.5) and we don't want to cancel the Scrutinizer analysis by notifying
+  # it than no coverage data is available
+  - if [[ "$TRAVIS_PHP_VERSION" != "7" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 after_failure:
   - cat /tmp/fos_nginx_error.log


### PR DESCRIPTION
PHP 7 and HHVM are not able to generate code coverage on Travis. If ocular is called in this case, it will report to Scrutinizer that the code coverage has not been collected, which will cancel the scrutinizer analysis if it is the first Travis job to finish (which is likely as generating code coverage would slow down the other jobs).