### PR TITLE
work around to avoid problems with the HttpKernel::loadClassCache mechanism

### DIFF
--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -63,6 +63,18 @@ When starting to extend your ``AppCache``, it is recommended to use the
 ``EventDispatchingHttpCacheTestCase`` to run tests with your kernel to be sure
 all events are triggered as expected.
 
+.. note::
+
+    If you use ``HttpKernel::loadClassCache`` from the console, you will need
+    to add ``class_exists('FOS\\HttpCache\\SymfonyCache\\CacheEvent');`` right
+    after the inclusion of ``bootstrap.php.cache`` in ``app/console``. For web
+    requests, this is done automatically by the trait. If you miss to do so,
+    you will get the following error:
+
+    .. code-block:: bash
+
+        Fatal error: Cannot redeclare class Symfony\Component\EventDispatcher\Event in app/cache/dev/classes.php on line ...
+
 Cache event listeners
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -78,6 +78,9 @@ trait EventDispatchingHttpCache
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        // trigger loading the CacheEvent to avoid fatal error when HttpKernel::loadClassCache is used.
+        class_exists('FOS\\HttpCache\\SymfonyCache\\CacheEvent');
+
         if ($response = $this->dispatch(Events::PRE_HANDLE, $request)) {
             return $this->dispatch(Events::POST_HANDLE, $request, $response);
         }


### PR DESCRIPTION
this is a follow-up of https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/244

it seems that we can run into problems with the cache of the HttpKernel. read here for more details: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/244#issuecomment-149525991