### PR TITLE
Replace 'Symfony2' with 'Symfony'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This library integrates your PHP applications with HTTP caching proxies such as 
 Use this library to send invalidation requests from your application to the caching proxy
 and to test your caching and invalidation code against a Varnish setup.
 
-If you use Symfony2, have a look at the
+If you use Symfony, have a look at the
 [FOSHttpCacheBundle](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle).
 The bundle provides the invalidator as a service, along with a number of
-Symfony2-specific features to help with caching and caching proxies.
+Symfony-specific features to help with caching and caching proxies.
 
 Features
 --------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,9 +8,9 @@ Varnish, NGINX or the Symfony HttpCache class. Use this library to send
 invalidation requests from your application to the caching proxy and to test
 your caching and invalidation setup.
 
-If you use the Symfony2 full stack framework, have a look at the FOSHttpCacheBundle_.
+If you use the Symfony full stack framework, have a look at the FOSHttpCacheBundle_.
 The bundle provides the Invalidator as a service, support for the built-in cache
-kernel of Symfony and a number of Symfony2-specific features to help with caching and
+kernel of Symfony and a number of Symfony-specific features to help with caching and
 caching proxies.
 
 Contents:

--- a/doc/invalidation-introduction.rst
+++ b/doc/invalidation-introduction.rst
@@ -99,7 +99,7 @@ Cache invalidation has two possible downsides:
   changed, a lot more is involved in invalidating all of its representations.
   In other words, invalidation adds a layer of complexity to your application.
   This library tries to help reduce complexity, for instance by
-  :ref:`tagging <tags>` cached content. Additionally, if you use Symfony2, we
+  :ref:`tagging <tags>` cached content. Additionally, if you use Symfony, we
   recommend you use the FOSHttpCacheBundle_.
   which provides additional functionality to make invalidation easier.
 * Invalidation is done through requests to your caching proxy. Sending these

--- a/doc/user-context.rst
+++ b/doc/user-context.rst
@@ -111,7 +111,7 @@ It is up to you to return the user context hash in response to the hash request
     // 406 Not acceptable in case of an incorrect accept header
     header('HTTP/1.1 406');
 
-If you use Symfony2, the FOSHttpCacheBundle_ will set the correct response
+If you use Symfony, the FOSHttpCacheBundle_ will set the correct response
 headers for you.
 
 Caching the Hash Response

--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -150,7 +150,7 @@ request with :ref:`a proper user hash <return context hash>`.
     We do not use ``X-Original-Url`` here, as the header will be sent to the
     backend and some applications look at this header, which would lead to
     problems. For example, the Microsoft IIS rewriting module uses this header
-    and Symfony2 has to look into that header to support IIS.
+    and Symfony has to look into that header to support IIS.
 
 .. note::
 


### PR DESCRIPTION
You know, with Symfony2 turning 3. :wink: