### PR TITLE
[cache tagging] http_resp_hdr_len check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog
 =========
+1.4.2
+-----
+
+* The TagHandler constructor now accepts a ``headerLenght`` argument which will
+  cause it's ``invalidateTags`` function to invalidate in batches if the header
+  length exceeds this value.
 
 1.3.3
 -----
@@ -11,9 +17,9 @@ Changelog
 
 * Added [TagHandler](http://foshttpcache.readthedocs.org/en/latest/invalidation-handlers.html#tag-handler).
 * It is no longer possible to change the event dispatcher of the
-  CacheInvalidator once its instantiated. If you need a custom dispatcher, set 
-  it right after creating the invalidator instance. 
-* Deprecated `CacheInvalidator::addSubscriber` in favor of either using the event 
+  CacheInvalidator once its instantiated. If you need a custom dispatcher, set
+  it right after creating the invalidator instance.
+* Deprecated `CacheInvalidator::addSubscriber` in favor of either using the event
   dispatcher instance you inject or doing `getEventDispatcher()->addSubscriber($subscriber)`.
 
 1.2.0

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -71,6 +71,11 @@ class CacheInvalidator
     private $tagsHeader = 'X-Cache-Tags';
 
     /**
+     * @var int
+     */
+    private $headerLength = 7500;
+
+    /**
      * Constructor
      *
      * @param ProxyClientInterface $cache HTTP cache
@@ -79,7 +84,7 @@ class CacheInvalidator
     {
         $this->cache = $cache;
         if ($cache instanceof BanInterface) {
-            $this->tagHandler = new TagHandler($this, $this->tagsHeader);
+            $this->tagHandler = new TagHandler($this, $this->tagsHeader, $this->headerLength);
         }
     }
 
@@ -172,7 +177,7 @@ class CacheInvalidator
     public function setTagsHeader($tagsHeader)
     {
         if ($this->tagHandler && $this->tagHandler->getTagsHeaderName() !== $tagsHeader) {
-            $this->tagHandler = new TagHandler($this, $tagsHeader);
+            $this->tagHandler = new TagHandler($this, $tagsHeader, $this->headerLength);
         }
 
         return $this;

--- a/tests/Unit/Handler/TagHandlerTest.php
+++ b/tests/Unit/Handler/TagHandlerTest.php
@@ -95,4 +95,32 @@ class TagHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($tagHandler->hasTags());
         $this->assertEquals('post-1,test_post', $tagHandler->getTagsHeaderValue());
     }
+
+    public function testInvalidateTwice()
+    {
+        $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
+            ->shouldReceive('supports')
+            ->with(CacheInvalidator::INVALIDATE)
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('invalidate')
+            ->twice()
+            ->getMock();
+
+        $tagHandler = new TagHandler($cacheInvalidator, 'X-Cache-Tags', 7);
+        $tagHandler->invalidateTags(array('post-1', 'post-2'));
+    }
+
+    public function testHeaderLength()
+    {
+        $cacheInvalidator = \Mockery::mock('FOS\HttpCache\CacheInvalidator')
+            ->shouldReceive('supports')
+            ->with(CacheInvalidator::INVALIDATE)
+            ->once()
+            ->andReturn(true)
+            ->getMock();
+
+        $tagHandler = new TagHandler($cacheInvalidator, 'X-Cache-Tags', 8000);
+        $this->assertEquals(8000, $tagHandler->getHeaderLength());
+    }
 }


### PR DESCRIPTION
fixes #269 

###### notes:
- as ``getTagsHeader`` and ``setTagsHeader`` are marked as depricated in the ``CacheInvalidator`` i didn't provide seperate functions for the ``headerLength``.
- as varnish' ``http_resp_hdr_len`` defaults to 8000 bytes, i defaulted the ``headerLength`` to 7500 bytes to be on the safe side