### PR TITLE
little doc cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
   cause it's ``invalidateTags`` function to invalidate in batches if the header
   length exceeds this value.
 
+1.4.1
+-----
+
+* Support for Symfony 3.
+
 1.4.0
 -----
 

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -87,32 +87,37 @@ Varnish runs on if it is not port 80::
     $servers = ['10.0.0.1', '10.0.0.2:6081']; // Port 80 assumed for 10.0.0.1
     $varnish = new Varnish($servers);
 
-This is sufficient for invalidating absolute URLs. If you also wish to
-invalidate relative paths, supply the hostname (or base URL) where your website
-is available as the value for the ``base_uri`` key in the second options parameter::
+This is sufficient for invalidating absolute URLs. If you want to use relative
+paths in invalidation requests, supply the hostname and possibly a base path to
+your website as ``base_uri`` option::
 
-    $varnish = new Varnish($servers, array('base_uri' => 'my-cool-app.com'));
+    $varnish = new Varnish($servers, ['base_uri' => 'my-cool-app.com']);
 
-Again, if you access your web application on a port other than 80, make sure to
+Again, if your web application is accessed on a port other than 80, make sure to
 include that port in the base URL::
 
-    $varnish = new Varnish($servers, array('base_uri' => 'my-cool-app.com:8080'));
+    $varnish = new Varnish($servers, ['base_uri' => 'my-cool-app.com:8080']);
 
 .. _varnish_custom_tags_header:
 
-Two other optional parameters available for the Varnish client are ``tags_header`` and ``header_length``.
-``tags_header`` allows you to change the default HTTP header used for tagging,
-while ``header_length`` allows you to change the maximum header size (in bytes) used to invalidate tags::
+The other options for the Varnish client are:
 
-    $options = array(
+* ``tags_header`` (X-Cache-Tags): Allows you to change the HTTP header used for
+  tagging. If you change this, make sure to use the correct header name in your
+  :doc:`caching proxy configuration <proxy-configuration>`;
+* ``header_length`` (7500): Control the maximum header size when invalidating
+  tags. If there are more tags to invalidate than fit into the header, the
+  invalidation request is split into several requests.
+
+A full example could look like this::
+
+    $options = [
         'base_uri' => 'example.com',
         'tags_header' => 'X-Custom-Tags-Header',
         'header_length' => 4000,
-    );
+    ];
 
     $varnish = new Varnish($servers, $options, $adapter);
-
-Make sure to reflect a change to ``tags_header`` in your :doc:`caching proxy configuration <proxy-configuration>`.
 
 .. note::
 

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -24,13 +24,11 @@ the ``TagsInterface``, handling adding tags to responses::
 
 .. _response_tagger_optional_parameters:
 
-An optional parameter for the response tagger is the ``strict`` boolean which can be
-passed in the options array as the second parameter of the constructor::
+The response tagger validates tags that you set. By default, it simply ignores
+empty strings. You can set the response tagger to strict mode to have it throw
+an ``InvalidTagException`` on empty tags::
 
-    $responseTagger = new ResponseTagger($proxyClient, array('strict' => true));
-
-Setting ``strict`` to ``true`` will cause the response tagger to throw an ``InvalidTagException``
-when an invalid tag is passed to the ``addTags`` method.
+    $responseTagger = new ResponseTagger($proxyClient, ['strict' => true]);
 
 Usage
 ~~~~~

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -99,7 +99,7 @@ the listeners you need there::
         HttpKernelInterface $kernel,
         StoreInterface $store,
         SurrogateInterface $surrogate = null,
-        array $options = array()
+        array $options = []
     ) {
         parent::__construct($kernel, $store, $surrogate, $options);
 


### PR DESCRIPTION
follow up of #275, and some other small things that where wrong (consistent short array notation for example)