### PR TITLE
drop the x- prefix from our custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 2.0.0 (unreleased)
 ------------------
 
+* Change all our custom headers to not use a `X-` prefix to comply with
+  [RFC 6648](http://tools.ietf.org/html/rfc6648#section-3).
 * Replace hard coupling on Guzzle HTTP client with HTTP adapter. You now need
   to explicitly specify the adapter you want, see [installation instructions]
   (http://foshttpcache.readthedocs.org/en/stable/installation.html)

--- a/doc/cache-invalidator.rst
+++ b/doc/cache-invalidator.rst
@@ -148,9 +148,9 @@ You can also invalidate the cache based on any headers.
 Cache client implementations should fill up the headers to at least have the
 default headers always present to simplify the cache configuration rules.
 
-To invalidate on a custom header ``X-My-Header``, you would do::
+To invalidate on a custom header ``My-Header``, you would do::
 
-    $cacheInvalidator->invalidate(['X-My-Header' => 'my-value'])->flush();
+    $cacheInvalidator->invalidate(['My-Header' => 'my-value'])->flush();
 
 .. _flush:
 

--- a/doc/includes/custom-ttl.rst
+++ b/doc/includes/custom-ttl.rst
@@ -12,6 +12,6 @@ the response to remove or reduce the ``s-maxage``. This is not a good solution
 however, as you start to duplicate your caching rule definitions.
 
 The solution to this issue provided here is to use a separate, different header
-called ``X-Reverse-Proxy-TTL`` that controls the TTL of the caching proxy to
+called ``Reverse-Proxy-TTL`` that controls the TTL of the caching proxy to
 keep ``s-maxage`` for other proxies. Because this is not a standard feature,
 you need to add configuration to your caching proxy.

--- a/doc/nginx-configuration.rst
+++ b/doc/nginx-configuration.rst
@@ -43,7 +43,7 @@ Refresh
 If you want to invalidate cached objects by forcing a :term:`refresh`
 you have to use the built-in `proxy_cache_bypass <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_bypass>`_
 directive. This directive defines conditions under which the response will not
-be taken from a cache. This library uses a custom HTTP header named ``X-Refresh``,
+be taken from a cache. This library uses a custom HTTP header named ``Refresh``,
 so add a line like the following to your config:
 
 .. literalinclude:: ../tests/Functional/Fixtures/nginx/fos.conf
@@ -55,9 +55,9 @@ so add a line like the following to your config:
 Debugging
 ~~~~~~~~~
 
-Configure your Nginx to set a custom header (`X-Cache`) that shows whether a
+Configure your Nginx to set a custom header (`Cache`) that shows whether a
 cache hit or miss occurred:
 
 .. code-block:: none
 
-    add_header X-Cache $upstream_cache_status;
+    add_header Cache $upstream_cache_status;

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -104,7 +104,7 @@ include that port in the base URL::
 
 The other options for the Varnish client are:
 
-* ``tags_header`` (X-Cache-Tags): Allows you to change the HTTP header used for
+* ``tags_header`` (Cache-Tags): Allows you to change the HTTP header used for
   tagging. If you change this, make sure to use the correct header name in your
   :doc:`caching proxy configuration <proxy-configuration>`;
 * ``header_length`` (7500): Control the maximum header size when invalidating
@@ -115,7 +115,7 @@ A full example could look like this::
 
     $options = [
         'base_uri' => 'example.com',
-        'tags_header' => 'X-Custom-Tags-Header',
+        'tags_header' => 'Custom-Tags-Header',
         'header_length' => 4000,
     ];
 
@@ -235,7 +235,7 @@ You can specify HTTP headers as the second argument to ``purge()``.
 For instance::
 
     $client
-        ->purge('/some/path', ['X-Foo' => 'bar'])
+        ->purge('/some/path', ['Foo' => 'bar'])
         ->flush()
     ;
 

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -56,7 +56,7 @@ Before any content is sent out, you need to send the tag header_::
 Assume you sent four responses:
 
 +------------+-------------------------+
-| Response:  | ``X-Cache-Tags`` header:|
+| Response:  | ``Cache-Tags`` header:|
 +============+=========================+
 | ``/one``   | ``tag-one``             |
 +------------+-------------------------+

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -191,7 +191,7 @@ options through the constructor:
 * **user_hash_header**: Name of the header the user context hash will be stored
   into. Must match the setup for the Vary header in the backend application.
 
-  **default**: ``X-User-Context-Hash``
+  **default**: ``User-Context-Hash``
 
 * **user_hash_uri**: Target URI used in the request for user context hash
   generation.
@@ -243,14 +243,14 @@ Custom TTL
 .. include:: includes/custom-ttl.rst
 
 The ``CustomTtlSubscriber`` looks at a specific header to determine the TTL,
-preferring that over ``s-maxage``. The default header is ``X-Reverse-Proxy-TTL``
+preferring that over ``s-maxage``. The default header is ``Reverse-Proxy-TTL``
 but you can customize that in the subscriber constructor::
 
     new CustomTtlSubscriber('My-TTL-Header');
 
 The custom header is removed before sending the response to the client.
 
-.. _symfony-cache x-debugging:
+.. _symfony-cache debugging:
 
 Debugging
 ~~~~~~~~~

--- a/doc/testing-your-application.rst
+++ b/doc/testing-your-application.rst
@@ -153,7 +153,7 @@ Enable Assertions
 '''''''''''''''''
 
 For the `assertHit` and `assertMiss` assertions to work, you need to add a
-:ref:`custom X-Cache header <varnish_debugging>` to responses served
+:ref:`custom Cache header <varnish_debugging>` to responses served
 by your Varnish.
 
 NginxTest Trait
@@ -225,11 +225,11 @@ CacheAssertions Trait
 
 Provides cache hit/miss assertions to your tests. To enable the these
 ``assertHit`` and ``assertMiss`` assertions, you need to configure your caching
-server to set an `X-Cache` header with the cache status:
+server to set an `Cache` header with the cache status:
 
 * :ref:`Varnish <varnish_debugging>`
 * :ref:`NGINX <nginx_debugging>`
-* :ref:`Symfony HttpCache <symfony-cache x-debugging>`
+* :ref:`Symfony HttpCache <symfony-cache debugging>`
 
 Then use the assertions as follows::
 

--- a/doc/user-context.rst
+++ b/doc/user-context.rst
@@ -48,12 +48,12 @@ Caching on user context works as follows:
 3. The :term:`application` receives the hash request. The application knows the
    client’s user context (roles, permissions, etc.) and generates a hash based
    on that information. The application then returns a response containing that
-   hash in a custom header (``X-User-Context-Hash``) and with ``Content-Type``
+   hash in a custom header (``User-Context-Hash``) and with ``Content-Type``
    ``application/vnd.fos.user-context-hash``.
 4. The caching proxy receives the hash response, copies the hash header to the
    client’s original request for ``/foo.php`` and restarts that request.
 5. If the response to this request should differ per user context, the
-   application specifies so by setting a ``Vary: X-User-Context-Hash`` header.
+   application specifies so by setting a ``Vary: User-Context-Hash`` header.
    The appropriate user role dependent representation of ``/foo.php`` will
    then be returned to the client.
 
@@ -139,7 +139,7 @@ It is up to you to return the user context hash in response to the hash request
     $hash = $hashGenerator->generateHash();
 
     if ('application/vnd.fos.user-context-hash' == strtolower($_SERVER['HTTP_ACCEPT'])) {
-        header(sprintf('X-User-Context-Hash: %s', $hash));
+        header(sprintf('User-Context-Hash: %s', $hash));
         header('Content-Type: application/vnd.fos.user-context-hash');
         exit;
     }
@@ -184,7 +184,7 @@ differently depending on whether the user is logged in or not, using the
 
     // /index.php file
     header('Cache-Control: max-age=3600');
-    header('Vary: X-User-Context-Hash');
+    header('Vary: User-Context-Hash');
 
     $authenticationService = new AuthenticationService();
 

--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -161,7 +161,7 @@ To enable support add the following to ``your_varnish.vcl``:
             call fos_ban_deliver;
         }
 
-This subroutine also sets the ``X-Url`` and ``X-Host`` headers on the cache
+This subroutine also sets the ``Url`` and ``Host`` headers on the cache
 object. These headers are used by the Varnish `ban lurker`_ that crawls the
 content to eventually throw out banned data even when it’s not requested by any
 client. Read more on `handling BAN requests`_ in the Varnish documentation (for
@@ -175,10 +175,10 @@ Tagging
 Feature: :ref:`cache tagging <tags>`
 
 If you have included ``fos_ban.vcl``, tagging will be automatically enabled
-using an ``X-Cache-Tags`` header.
+using an ``Cache-Tags`` header.
 
 If you need to use a different tag for the headers than the default
-``X-Cache-Tags`` used in ``fos_ban.vcl``, you will have to write your own VCL
+``Cache-Tags`` used in ``fos_ban.vcl``, you will have to write your own VCL
 code for tag invalidation and change the tagging header
 :ref:`configured in the cache invalidator <varnish_custom_tags_header>`. Your custom
 VCL will look like this:
@@ -261,13 +261,6 @@ To enable support add the following to ``your_varnish.vcl``:
 
 Your backend application needs to respond to the ``application/vnd.fos.user-context-hash``
 request with :ref:`a proper user hash <return context hash>`.
-
-.. note::
-
-    We do not use ``X-Original-Url`` here, as the header will be sent to the
-    backend and the header has semantical meaning for some applications, which
-    would lead to problems. For example, the Microsoft IIS rewriting module
-    uses it, and consequently Symfony also looks into it to support IIS.
 
 .. tip::
 
@@ -352,9 +345,9 @@ The custom header is removed before sending the response to the client.
 Debugging
 ~~~~~~~~~
 
-Configure your Varnish to set a custom header (``X-Cache``) that shows whether a
+Configure your Varnish to set a custom header (``Cache``) that shows whether a
 cache hit or miss occurred. This header will only be set if your application
-sends an ``X-Cache-Debug`` header:
+sends an ``Cache-Debug`` header:
 
 Subroutines are provided in ``fos_debug.vcl``.
 

--- a/resources/config/varnish-3/fos_ban.vcl
+++ b/resources/config/varnish-3/fos_ban.vcl
@@ -14,16 +14,16 @@ sub fos_ban_recv {
             error 405 "Not allowed.";
         }
 
-        if (req.http.X-Cache-Tags) {
-            ban("obj.http.X-Host ~ " + req.http.X-Host
-                + " && obj.http.X-Url ~ " + req.http.X-Url
-                + " && obj.http.content-type ~ " + req.http.X-Content-Type
-                + " && obj.http.X-Cache-Tags ~ " + req.http.X-Cache-Tags
+        if (req.http.Cache-Tags) {
+            ban("obj.http.Host ~ " + req.http.Ban-Host
+                + " && obj.http.Url ~ " + req.http.Ban-Url
+                + " && obj.http.content-type ~ " + req.http.Ban-Content-Type
+                + " && obj.http.Cache-Tags ~ " + req.http.Ban-Cache-Tags
             );
         } else {
-            ban("obj.http.X-Host ~ " + req.http.X-Host
-                + " && obj.http.X-Url ~ " + req.http.X-Url
-                + " && obj.http.content-type ~ " + req.http.X-Content-Type
+            ban("obj.http.Host ~ " + req.http.Host
+                + " && obj.http.Url ~ " + req.http.Url
+                + " && obj.http.content-type ~ " + req.http.Content-Type
             );
         }
 
@@ -34,19 +34,19 @@ sub fos_ban_recv {
 sub fos_ban_fetch {
 
     # Set ban-lurker friendly custom headers
-    set beresp.http.X-Url = req.url;
-    set beresp.http.X-Host = req.http.host;
+    set beresp.http.Url = req.url;
+    set beresp.http.Host = req.http.host;
 }
 
 sub fos_ban_deliver {
 
     # Keep ban-lurker headers only if debugging is enabled
-    if (!resp.http.X-Cache-Debug) {
+    if (!resp.http.Cache-Debug) {
         # Remove ban-lurker friendly custom headers when delivering to client
-        unset resp.http.X-Url;
-        unset resp.http.X-Host;
+        unset resp.http.Url;
+        unset resp.http.Host;
 
         # Unset the tagged cache headers
-        unset resp.http.X-Cache-Tags;
+        unset resp.http.Cache-Tags;
     }
 }

--- a/resources/config/varnish-3/fos_custom_ttl.vcl
+++ b/resources/config/varnish-3/fos_custom_ttl.vcl
@@ -12,7 +12,7 @@
  * instead of s-maxage.
  */
 sub fos_custom_ttl_fetch {
-    if (beresp.http.X-Reverse-Proxy-TTL) {
+    if (beresp.http.Reverse-Proxy-TTL) {
         /*
          * Note that there is a ``beresp.ttl`` field in VCL but unfortunately
          * it can only be set to absolute values and not dynamically. Thus we
@@ -20,10 +20,10 @@ sub fos_custom_ttl_fetch {
          */
         C{
             char *ttl;
-            ttl = VRT_GetHdr(sp, HDR_BERESP, "\024X-Reverse-Proxy-TTL:");
+            ttl = VRT_GetHdr(sp, HDR_BERESP, "\024Reverse-Proxy-TTL:");
             VRT_l_beresp_ttl(sp, atoi(ttl));
         }C
 
-        unset beresp.http.X-Reverse-Proxy-TTL;
+        unset beresp.http.Reverse-Proxy-TTL;
     }
 }

--- a/resources/config/varnish-3/fos_debug.vcl
+++ b/resources/config/varnish-3/fos_debug.vcl
@@ -9,11 +9,11 @@
 
 sub fos_debug_deliver {
     # Add extra headers if debugging is enabled
-    if (resp.http.X-Cache-Debug) {
+    if (resp.http.Cache-Debug) {
         if (obj.hits > 0) {
-            set resp.http.X-Cache = "HIT";
+            set resp.http.Cache = "HIT";
         } else {
-            set resp.http.X-Cache = "MISS";
+            set resp.http.Cache = "MISS";
         }
     }
 }

--- a/resources/config/varnish-3/fos_user_context.vcl
+++ b/resources/config/varnish-3/fos_user_context.vcl
@@ -12,7 +12,7 @@ sub fos_user_context_recv {
     # Prevent tampering attacks on the hash mechanism
     if (req.restarts == 0
         && (req.http.accept ~ "application/vnd.fos.user-context-hash"
-            || req.http.X-User-Context-Hash
+            || req.http.User-Context-Hash
         )
     ) {
         error 400;
@@ -27,13 +27,13 @@ sub fos_user_context_recv {
     ) {
         # Backup accept header, if set
         if (req.http.accept) {
-            set req.http.X-Fos-Original-Accept = req.http.accept;
+            set req.http.Fos-Original-Accept = req.http.accept;
         }
         set req.http.accept = "application/vnd.fos.user-context-hash";
 
         # Backup original URL
-        set req.http.X-Fos-Original-Url = req.url;
-        
+        set req.http.Fos-Original-Url = req.url;
+
         call user_context_hash_url;
 
         # Force the lookup, the backend must tell not to cache or vary on all
@@ -45,11 +45,11 @@ sub fos_user_context_recv {
     if (req.restarts > 0
         && req.http.accept == "application/vnd.fos.user-context-hash"
     ) {
-        set req.url = req.http.X-Fos-Original-Url;
-        unset req.http.X-Fos-Original-Url;
-        if (req.http.X-Fos-Original-Accept) {
-            set req.http.accept = req.http.X-Fos-Original-Accept;
-            unset req.http.X-Fos-Original-Accept;
+        set req.url = req.http.Fos-Original-Url;
+        unset req.http.Fos-Original-Url;
+        if (req.http.Fos-Original-Accept) {
+            set req.http.accept = req.http.Fos-Original-Accept;
+            unset req.http.Fos-Original-Accept;
         } else {
             # If accept header was not set in original request, remove the header here.
             unset req.http.accept;
@@ -78,7 +78,7 @@ sub fos_user_context_deliver {
         && resp.http.content-type ~ "application/vnd.fos.user-context-hash"
         && resp.status == 200
     ) {
-        set req.http.X-User-Context-Hash = resp.http.X-User-Context-Hash;
+        set req.http.User-Context-Hash = resp.http.User-Context-Hash;
 
         return (restart);
     }
@@ -87,12 +87,12 @@ sub fos_user_context_deliver {
 
     # Remove the vary on context user hash, this is nothing public. Keep all
     # other vary headers.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
+    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *User-Context-Hash *", "");
     set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
     if (resp.http.Vary == "") {
         remove resp.http.Vary;
     }
 
     # Sanity check to prevent ever exposing the hash to a client.
-    remove resp.http.X-User-Context-Hash;
+    remove resp.http.User-Context-Hash;
 }

--- a/resources/config/varnish-4/fos_ban.vcl
+++ b/resources/config/varnish-4/fos_ban.vcl
@@ -14,16 +14,16 @@ sub fos_ban_recv {
             return (synth(405, "Not allowed"));
         }
 
-        if (req.http.X-Cache-Tags) {
-            ban("obj.http.X-Host ~ " + req.http.X-Host
-                + " && obj.http.X-Url ~ " + req.http.X-Url
-                + " && obj.http.content-type ~ " + req.http.X-Content-Type
-                + " && obj.http.X-Cache-Tags ~ " + req.http.X-Cache-Tags
+        if (req.http.Cache-Tags) {
+            ban("obj.http.Host ~ " + req.http.Host
+                + " && obj.http.Url ~ " + req.http.Url
+                + " && obj.http.content-type ~ " + req.http.Content-Type
+                + " && obj.http.Cache-Tags ~ " + req.http.Cache-Tags
             );
         } else {
-            ban("obj.http.X-Host ~ " + req.http.X-Host
-                + " && obj.http.X-Url ~ " + req.http.X-Url
-                + " && obj.http.content-type ~ " + req.http.X-Content-Type
+            ban("obj.http.Host ~ " + req.http.Host
+                + " && obj.http.Url ~ " + req.http.Url
+                + " && obj.http.content-type ~ " + req.http.Content-Type
             );
         }
 
@@ -34,19 +34,19 @@ sub fos_ban_recv {
 sub fos_ban_backend_response {
 
     # Set ban-lurker friendly custom headers
-    set beresp.http.X-Url = bereq.url;
-    set beresp.http.X-Host = bereq.http.host;
+    set beresp.http.Url = bereq.url;
+    set beresp.http.Host = bereq.http.host;
 }
 
 sub fos_ban_deliver {
 
     # Keep ban-lurker headers only if debugging is enabled
-    if (!resp.http.X-Cache-Debug) {
+    if (!resp.http.Cache-Debug) {
         # Remove ban-lurker friendly custom headers when delivering to client
-        unset resp.http.X-Url;
-        unset resp.http.X-Host;
+        unset resp.http.Url;
+        unset resp.http.Host;
 
         # Unset the tagged cache headers
-        unset resp.http.X-Cache-Tags;
+        unset resp.http.Cache-Tags;
     }
 }

--- a/resources/config/varnish-4/fos_custom_ttl.vcl
+++ b/resources/config/varnish-4/fos_custom_ttl.vcl
@@ -15,7 +15,7 @@ C{
  * instead of s-maxage.
  */
 sub fos_custom_ttl_backend_response {
-    if (beresp.http.X-Reverse-Proxy-TTL) {
+    if (beresp.http.Reverse-Proxy-TTL) {
         /*
          * Note that there is a ``beresp.ttl`` field in VCL but unfortunately
          * it can only be set to absolute values and not dynamically. Thus we
@@ -27,11 +27,11 @@ sub fos_custom_ttl_backend_response {
          */
         C{
             const char *ttl;
-            const struct gethdr_s hdr = { HDR_BERESP, "\024X-Reverse-Proxy-TTL:" };
+            const struct gethdr_s hdr = { HDR_BERESP, "\024Reverse-Proxy-TTL:" };
             ttl = VRT_GetHdr(ctx, &hdr);
             VRT_l_beresp_ttl(ctx, atoi(ttl));
         }C
 
-        unset beresp.http.X-Reverse-Proxy-TTL;
+        unset beresp.http.Reverse-Proxy-TTL;
     }
 }

--- a/resources/config/varnish-4/fos_debug.vcl
+++ b/resources/config/varnish-4/fos_debug.vcl
@@ -10,13 +10,13 @@
 sub fos_debug_deliver {
     # Add extra headers if debugging is enabled
     # In Varnish 4 the obj.hits counter behaviour has changed, so we use a
-    # different method: if X-Varnish contains only 1 id, we have a miss, if it
+    # different method: if Varnish contains only 1 id, we have a miss, if it
     # contains more (and therefore a space), we have a hit.
-    if (resp.http.X-Cache-Debug) {
-        if (resp.http.X-Varnish ~ " ") {
-            set resp.http.X-Cache = "HIT";
+    if (resp.http.Cache-Debug) {
+        if (resp.http.Varnish ~ " ") {
+            set resp.http.Cache = "HIT";
         } else {
-            set resp.http.X-Cache = "MISS";
+            set resp.http.Cache = "MISS";
         }
     }
 }

--- a/resources/config/varnish-4/fos_user_context.vcl
+++ b/resources/config/varnish-4/fos_user_context.vcl
@@ -12,7 +12,7 @@ sub fos_user_context_recv {
     # Prevent tampering attacks on the hash mechanism
     if (req.restarts == 0
         && (req.http.accept ~ "application/vnd.fos.user-context-hash"
-            || req.http.X-User-Context-Hash
+            || req.http.User-Context-Hash
         )
     ) {
         return (synth(400));
@@ -27,13 +27,13 @@ sub fos_user_context_recv {
     ) {
         # Backup accept header, if set
         if (req.http.accept) {
-            set req.http.X-Fos-Original-Accept = req.http.accept;
+            set req.http.Fos-Original-Accept = req.http.accept;
         }
         set req.http.accept = "application/vnd.fos.user-context-hash";
 
         # Backup original URL
-        set req.http.X-Fos-Original-Url = req.url;
-        
+        set req.http.Fos-Original-Url = req.url;
+
         call user_context_hash_url;
 
         # Force the lookup, the backend must tell not to cache or vary on all
@@ -45,11 +45,11 @@ sub fos_user_context_recv {
     if (req.restarts > 0
         && req.http.accept == "application/vnd.fos.user-context-hash"
     ) {
-        set req.url = req.http.X-Fos-Original-Url;
-        unset req.http.X-Fos-Original-Url;
-        if (req.http.X-Fos-Original-Accept) {
-            set req.http.accept = req.http.X-Fos-Original-Accept;
-            unset req.http.X-Fos-Original-Accept;
+        set req.url = req.http.Fos-Original-Url;
+        unset req.http.Fos-Original-Url;
+        if (req.http.Fos-Original-Accept) {
+            set req.http.accept = req.http.Fos-Original-Accept;
+            unset req.http.Fos-Original-Accept;
         } else {
             # If accept header was not set in original request, remove the header here.
             unset req.http.accept;
@@ -76,7 +76,7 @@ sub fos_user_context_deliver {
     if (req.restarts == 0
         && resp.http.content-type ~ "application/vnd.fos.user-context-hash"
     ) {
-        set req.http.X-User-Context-Hash = resp.http.X-User-Context-Hash;
+        set req.http.User-Context-Hash = resp.http.User-Context-Hash;
 
         return (restart);
     }
@@ -85,12 +85,12 @@ sub fos_user_context_deliver {
 
     # Remove the vary on context user hash, this is nothing public. Keep all
     # other vary headers.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
+    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *User-Context-Hash *", "");
     set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
     if (resp.http.Vary == "") {
         unset resp.http.Vary;
     }
 
     # Sanity check to prevent ever exposing the hash to a client.
-    unset resp.http.X-User-Context-Hash;
+    unset resp.http.User-Context-Hash;
 }

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -184,7 +184,7 @@ class CacheInvalidator
      * Invalidate all cached objects matching the provided HTTP headers.
      *
      * Each header is a a POSIX regular expression, for example
-     * ['X-Host' => '^(www\.)?(this|that)\.com$']
+     * ['Host' => '^(www\.)?(this|that)\.com$']
      *
      * @see BanInterface::ban()
      *

--- a/src/ProxyClient/Invalidation/BanInterface.php
+++ b/src/ProxyClient/Invalidation/BanInterface.php
@@ -26,13 +26,13 @@ interface BanInterface extends ProxyClientInterface
      * Ban cached objects matching HTTP headers.
      *
      * Each header is either a:
-     * - regular string ('X-Host' => 'example.com')
-     * - or a POSIX regular expression ('X-Host' => '^(www\.)?(this|that)\.com$').
+     * - regular string ('Host' => 'example.com')
+     * - or a POSIX regular expression ('Host' => '^(www\.)?(this|that)\.com$').
      *
      * Please make sure to configure your HTTP caching proxy to set the headers
      * supplied here on the cached objects. So if you want to match objects by
      * host name, configure your proxy to copy the host to a custom HTTP header
-     * such as X-Host.
+     * such as Host.
      *
      * @param array $headers HTTP headers that path must match to be banned
      *

--- a/src/ProxyClient/Nginx.php
+++ b/src/ProxyClient/Nginx.php
@@ -23,7 +23,7 @@ class Nginx extends AbstractProxyClient implements PurgeInterface, RefreshInterf
 {
     const HTTP_METHOD_PURGE = 'PURGE';
     const HTTP_METHOD_REFRESH = 'GET';
-    const HTTP_HEADER_REFRESH = 'X-Refresh';
+    const HTTP_HEADER_REFRESH = 'Refresh';
 
     /**
      * Path location that triggers purging. If false, same location purging is

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -23,7 +23,7 @@ use Http\Message\MessageFactory;
  * Varnish HTTP cache invalidator.
  *
  * Additional constructor options:
- * - tags_header   Header for tagging responses, defaults to X-Cache-Tags
+ * - tags_header   Header for tagging responses, defaults to Cache-Tags
  * - header_length Maximum header length, defaults to 7500 bytes
  *
  * @author David de Boer <david@driebit.nl>
@@ -33,9 +33,9 @@ class Varnish extends AbstractProxyClient implements BanInterface, PurgeInterfac
     const HTTP_METHOD_BAN = 'BAN';
     const HTTP_METHOD_PURGE = 'PURGE';
     const HTTP_METHOD_REFRESH = 'GET';
-    const HTTP_HEADER_HOST = 'X-Host';
-    const HTTP_HEADER_URL = 'X-Url';
-    const HTTP_HEADER_CONTENT_TYPE = 'X-Content-Type';
+    const HTTP_HEADER_HOST = 'Host';
+    const HTTP_HEADER_URL = 'Url';
+    const HTTP_HEADER_CONTENT_TYPE = 'Content-Type';
 
     /**
      * Map of default headers for ban requests with their default values.
@@ -192,7 +192,7 @@ class Varnish extends AbstractProxyClient implements BanInterface, PurgeInterfac
     protected function getDefaultOptions()
     {
         $resolver = parent::getDefaultOptions();
-        $resolver->setDefaults(['tags_header' => 'X-Cache-Tags']);
+        $resolver->setDefaults(['tags_header' => 'Cache-Tags']);
         $resolver->setDefaults(['header_length' => 7500]);
 
         return $resolver;

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -40,7 +40,7 @@ class CustomTtlListener implements EventSubscriberInterface
     /**
      * @param string $ttlHeader The header that is used to specify the TTL header
      */
-    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL')
+    public function __construct($ttlHeader = 'Reverse-Proxy-TTL')
     {
         $this->ttlHeader = $ttlHeader;
     }

--- a/src/SymfonyCache/DebugListener.php
+++ b/src/SymfonyCache/DebugListener.php
@@ -54,7 +54,7 @@ class DebugListener implements EventSubscriberInterface
             } else {
                 $state = 'UNDETERMINED';
             }
-            $response->headers->set('X-Cache', $state);
+            $response->headers->set('-Cache', $state);
         }
     }
 }

--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -62,7 +62,7 @@ class UserContextSubscriber implements EventSubscriberInterface
         $resolver->setDefaults([
             'anonymous_hash' => '38015b703d82206ebc01d17a39c727e5',
             'user_hash_accept_header' => 'application/vnd.fos.user-context-hash',
-            'user_hash_header' => 'X-User-Context-Hash',
+            'user_hash_header' => 'User-Context-Hash',
             'user_hash_uri' => '/_fos_user_context_hash',
             'user_hash_method' => 'GET',
             'session_name_prefix' => 'PHPSESSID',

--- a/src/Test/CacheAssertions.php
+++ b/src/Test/CacheAssertions.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ResponseInterface;
  * Provides cache hit/miss assertions to PHPUnit tests.
  *
  * To enable the assertHit and assertMiss assertions, you need to configure your
- * caching proxy to set an X-Cache header with the cache status.
+ * caching proxy to set an Cache header with the cache status.
  *
  * Use this trait in conjunction with either the NginxTest, SymfonyTest or
  * VarnishTest trait to reset the cache between tests and properly isolate your

--- a/src/Test/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraint.php
@@ -18,12 +18,12 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class AbstractCacheConstraint extends \PHPUnit_Framework_Constraint
 {
-    protected $header = 'X-Cache';
+    protected $header = 'Cache';
 
     /**
      * Constructor.
      *
-     * @param string $header Cache debug header; defaults to X-Cache-Debug
+     * @param string $header Cache debug header; defaults to Cache-Debug
      */
     public function __construct($header = null)
     {

--- a/tests/Functional/Fixtures/nginx/fos.conf
+++ b/tests/Functional/Fixtures/nginx/fos.conf
@@ -7,7 +7,7 @@ events {
 http {
 
     log_format proxy_cache '$time_local '
-        '"$upstream_cache_status | X-Refresh: $http_x_refresh" '
+        '"$upstream_cache_status | Refresh: $http_x_refresh" '
         '"$request" ($status) '
         '"$http_user_agent" ';
 
@@ -17,7 +17,7 @@ http {
     proxy_cache_path /tmp/foshttpcache-nginx keys_zone=FOS_CACHE:10m;
 
     # Add an HTTP header with the cache status. Required for FOSHttpCache tests.
-    add_header X-Cache $upstream_cache_status;
+    add_header Cache $upstream_cache_status;
 
     server {
 

--- a/tests/Functional/Fixtures/varnish-3/debug_user_context.vcl
+++ b/tests/Functional/Fixtures/varnish-3/debug_user_context.vcl
@@ -1,20 +1,20 @@
 sub vcl_deliver {
-    set resp.http.X-HashCache = "MISS";
+    set resp.http.HashCache = "MISS";
 
     if (resp.http.content-type ~ "application/vnd.fos.user-context-hash") {
         if (obj.hits > 0) {
-            set req.http.X-HashCache = "HIT";
+            set req.http.HashCache = "HIT";
         }
-    } elsif (req.http.X-HashCache) {
-        set resp.http.X-HashCache = req.http.X-HashCache;
+    } elsif (req.http.HashCache) {
+        set resp.http.HashCache = req.http.HashCache;
     }
 }
 
 sub user_context_hash_url {
     # A little hack for testing all scenarios
-    if ("failure" == req.http.X-Cache-Hash) {
+    if ("failure" == req.http.Cache-Hash) {
         set req.url = "/user_context_hash_failure.php";
-    } elsif (req.http.X-Cache-Hash) {
+    } elsif (req.http.Cache-Hash) {
         set req.url = "/user_context_hash_cache.php";
     } else {
         set req.url = "/user_context_hash_nocache.php";

--- a/tests/Functional/Fixtures/varnish-3/user_context_cache.vcl
+++ b/tests/Functional/Fixtures/varnish-3/user_context_cache.vcl
@@ -10,7 +10,7 @@ sub vcl_recv {
         && (req.http.cookie || req.http.authorization)
         && (req.request == "GET" || req.request == "HEAD")
     ) {
-        set req.http.X-Cache-Hash = "true";
+        set req.http.Cache-Hash = "true";
     }
 }
 

--- a/tests/Functional/Fixtures/varnish-3/user_context_failure.vcl
+++ b/tests/Functional/Fixtures/varnish-3/user_context_failure.vcl
@@ -10,7 +10,7 @@ sub vcl_recv {
         && (req.http.cookie || req.http.authorization)
         && (req.request == "GET" || req.request == "HEAD")
     ) {
-        set req.http.X-Cache-Hash = "failure";
+        set req.http.Cache-Hash = "failure";
     }
 
 }

--- a/tests/Functional/Fixtures/varnish-4/user_context_cache.vcl
+++ b/tests/Functional/Fixtures/varnish-4/user_context_cache.vcl
@@ -12,7 +12,7 @@ sub vcl_recv {
         && (req.http.cookie || req.http.authorization)
         && (req.method == "GET" || req.method == "HEAD")
     ) {
-        set req.http.X-Cache-Hash = "true";
+        set req.http.Cache-Hash = "true";
     }
 }
 

--- a/tests/Functional/Fixtures/varnish-4/user_context_failure.vcl
+++ b/tests/Functional/Fixtures/varnish-4/user_context_failure.vcl
@@ -12,7 +12,7 @@ sub vcl_recv {
         && (req.http.cookie || req.http.authorization)
         && (req.method == "GET" || req.method == "HEAD")
     ) {
-        set req.http.X-Cache-Hash = "failure";
+        set req.http.Cache-Hash = "failure";
     }
 }
 

--- a/tests/Functional/Fixtures/web/cache.php
+++ b/tests/Functional/Fixtures/web/cache.php
@@ -11,6 +11,6 @@
 
 header('Cache-Control: max-age=3600');
 header('Content-Type: text/html');
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 echo microtime(true);

--- a/tests/Functional/Fixtures/web/custom-ttl.php
+++ b/tests/Functional/Fixtures/web/custom-ttl.php
@@ -10,8 +10,8 @@
  */
 
 header('Cache-Control: s-maxage=0');
-header('X-Reverse-Proxy-TTL: 3600');
+header('Reverse-Proxy-TTL: 3600');
 header('Content-Type: text/html');
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 echo microtime(true);

--- a/tests/Functional/Fixtures/web/json.php
+++ b/tests/Functional/Fixtures/web/json.php
@@ -11,4 +11,4 @@
 
 header('Cache-Control: max-age=3600');
 header('Content-Type: text/json');
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');

--- a/tests/Functional/Fixtures/web/negotation.php
+++ b/tests/Functional/Fixtures/web/negotation.php
@@ -11,5 +11,5 @@
 
 header('Cache-Control: max-age=3600');
 header(sprintf('Content-Type: %s', $_SERVER['HTTP_ACCEPT']));
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 header('Vary: Accept');

--- a/tests/Functional/Fixtures/web/tags.php
+++ b/tests/Functional/Fixtures/web/tags.php
@@ -11,5 +11,5 @@
 
 header('Cache-Control: max-age=3600');
 header('Content-Type: text/html');
-header('X-Cache-Tags: tag1,tag2');
-header('X-Cache-Debug: 1');
+header('Cache-Tags: tag1,tag2');
+header('Cache-Debug: 1');

--- a/tests/Functional/Fixtures/web/user_context.php
+++ b/tests/Functional/Fixtures/web/user_context.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 if (isset($_GET['accept'])) {
     if ($_GET['accept'] != $_SERVER['HTTP_ACCEPT']) {
@@ -21,23 +21,23 @@ if (isset($_GET['accept'])) {
     exit;
 }
 
-if ('POST' == strtoupper($_SERVER['REQUEST_METHOD'])) {
+if ('POST' === strtoupper($_SERVER['REQUEST_METHOD'])) {
     echo 'POST';
     exit;
 }
 
-if (!isset($_COOKIE[0]) || ($_COOKIE[0] != 'foo' && $_COOKIE[0] != 'bar')) {
+if (!isset($_COOKIE[0]) || ($_COOKIE[0] !== "foo" && $_COOKIE[0] !== "bar")) {
     header('HTTP/1.1 403');
     exit;
 }
 
 header('Cache-Control: max-age=3600');
-header('Vary: X-User-Context-Hash');
+header('Vary: User-Context-Hash');
 
-if ($_COOKIE[0] == 'foo') {
-    header('X-HashTest: foo');
-    echo 'foo';
+if ($_COOKIE[0] === "foo") {
+    header('HashTest: foo');
+    echo "foo";
 } else {
-    header('X-HashTest: bar');
-    echo 'bar';
+    header('HashTest: bar');
+    echo "bar";
 }

--- a/tests/Functional/Fixtures/web/user_context_anon.php
+++ b/tests/Functional/Fixtures/web/user_context_anon.php
@@ -9,18 +9,18 @@
  * file that was distributed with this source code.
  */
 
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 header('Cache-Control: max-age=3600');
-header('Vary: X-User-Context-Hash');
+header('Vary: User-Context-Hash');
 
 if (!isset($_COOKIE[0])) {
-    header('X-HashTest: anonymous');
+    header('HashTest: anonymous');
     echo 'anonymous';
-} elseif ($_COOKIE[0] == 'foo') {
-    header('X-HashTest: foo');
+} elseif ($_COOKIE[0] === 'foo') {
+    header('HashTest: foo');
     echo 'foo';
 } else {
-    header('X-HashTest: bar');
+    header('HashTest: bar');
     echo 'bar';
 }

--- a/tests/Functional/Fixtures/web/user_context_hash_cache.php
+++ b/tests/Functional/Fixtures/web/user_context_hash_cache.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 // The application listens for hash request (by checking the accept header)
-// and creates an X-User-Context-Hash based on parameters in the request.
+// and creates an User-Context-Hash based on parameters in the request.
 // In this case it's based on Cookie.
-if ('application/vnd.fos.user-context-hash' == strtolower($_SERVER['HTTP_ACCEPT'])) {
-    header(sprintf('X-User-Context-Hash: %s', $_COOKIE[0]));
+if ('application/vnd.fos.user-context-hash' === strtolower($_SERVER['HTTP_ACCEPT'])) {
+    header(sprintf('User-Context-Hash: %s', $_COOKIE[0]));
     header('Content-Type: application/vnd.fos.user-context-hash');
     header('Cache-Control: max-age=3600');
     header('Vary: cookie, authorization');

--- a/tests/Functional/Fixtures/web/user_context_hash_failure.php
+++ b/tests/Functional/Fixtures/web/user_context_hash_failure.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 // The application listens for hash request (by checking the accept header)
-// and creates an X-User-Context-Hash based on parameters in the request.
+// and creates an User-Context-Hash based on parameters in the request.
 // In this case it's based on Cookie.
-if ('application/vnd.fos.user-context-hash' == strtolower($_SERVER['HTTP_ACCEPT'])) {
-    header(sprintf('X-User-Context-Hash: %s', 'failed'));
+if ('application/vnd.fos.user-context-hash' === strtolower($_SERVER['HTTP_ACCEPT'])) {
+    header(sprintf('User-Context-Hash: %s', 'failed'));
     header('Content-Type: application/vnd.fos.user-context-hash');
     header('Cache-Control: max-age=3600');
     header('Vary: cookie, authorization');

--- a/tests/Functional/Fixtures/web/user_context_hash_nocache.php
+++ b/tests/Functional/Fixtures/web/user_context_hash_nocache.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-header('X-Cache-Debug: 1');
+header('Cache-Debug: 1');
 
 // The application listens for hash request (by checking the accept header)
-// and creates an X-User-Context-Hash based on parameters in the request.
+// and creates an User-Context-Hash based on parameters in the request.
 // In this case it's based on Cookie.
-if ('application/vnd.fos.user-context-hash' == strtolower($_SERVER['HTTP_ACCEPT'])) {
-    header(sprintf('X-User-Context-Hash: %s', $_COOKIE[0]));
+if ('application/vnd.fos.user-context-hash' === strtolower($_SERVER['HTTP_ACCEPT'])) {
+    header(sprintf('User-Context-Hash: %s', $_COOKIE[0]));
     header('Content-Type: application/vnd.fos.user-context-hash');
     header('Cache-Control: max-age=0, no-cache, private');
 

--- a/tests/Functional/Varnish/UserContextFailureTest.php
+++ b/tests/Functional/Varnish/UserContextFailureTest.php
@@ -43,7 +43,7 @@ class UserContextFailureTest extends VarnishTestCase
             ]
         );
         $this->assertEquals(400, $response->getStatusCode());
-        $this->assertFalse($response->hasHeader('X-User-Context-Hash'));
+        $this->assertFalse($response->hasHeader('User-Context-Hash'));
     }
 
     /**
@@ -54,7 +54,7 @@ class UserContextFailureTest extends VarnishTestCase
         $response = $this->getResponse(
             '/user_context_hash_nocache.php',
             [
-                'X-User-Context-Hash' => 'miam',
+                'User-Context-Hash' => 'miam',
                 'Cookie' => ['0=miam'],
             ]
         );
@@ -77,7 +77,7 @@ class UserContextFailureTest extends VarnishTestCase
         );
 
         $this->assertEquals('POST', $postResponse->getBody());
-        $this->assertEquals('MISS', $postResponse->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $postResponse->getHeaderLine('HashCache'));
         $this->assertMiss($postResponse);
     }
 

--- a/tests/Functional/Varnish/UserContextTestCase.php
+++ b/tests/Functional/Varnish/UserContextTestCase.php
@@ -36,30 +36,30 @@ abstract class UserContextTestCase extends VarnishTestCase
     {
         $response1 = $this->getResponse('/user_context.php', ['Cookie' => ['0=foo']]);
         $this->assertEquals('foo', (string) $response1->getBody());
-        $this->assertEquals('MISS', $response1->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $response1->getHeaderLine('HashCache'));
 
         $response2 = $this->getResponse('/user_context.php', ['Cookie' => ['0=bar']]);
         $this->assertEquals('bar', (string) $response2->getBody());
-        $this->assertEquals('MISS', $response2->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $response2->getHeaderLine('HashCache'));
 
         $cachedResponse1 = $this->getResponse('/user_context.php', ['Cookie' => ['0=foo']]);
         $this->assertEquals('foo', (string) $cachedResponse1->getBody());
-        $this->assertContextCache($cachedResponse1->getHeaderLine('X-HashCache'));
+        $this->assertContextCache($cachedResponse1->getHeaderLine('HashCache'));
         $this->assertHit($cachedResponse1);
 
         $cachedResponse2 = $this->getResponse('/user_context.php', ['Cookie' => ['0=bar']]);
         $this->assertEquals('bar', $cachedResponse2->getBody());
-        $this->assertContextCache($cachedResponse2->getHeaderLine('X-HashCache'));
+        $this->assertContextCache($cachedResponse2->getHeaderLine('HashCache'));
         $this->assertHit($cachedResponse2);
 
         $headResponse1 = $this->getResponse('/user_context.php', ['Cookie' => ['0=foo'], [], 'HEAD']);
-        $this->assertEquals('foo', $headResponse1->getHeaderLine('X-HashTest'));
-        $this->assertContextCache($headResponse1->getHeaderLine('X-HashCache'));
+        $this->assertEquals('foo', $headResponse1->getHeaderLine('HashTest'));
+        $this->assertContextCache($headResponse1->getHeaderLine('HashCache'));
         $this->assertHit($headResponse1);
 
         $headResponse2 = $this->getResponse('/user_context.php', ['Cookie' => ['0=bar'], [], 'HEAD']);
-        $this->assertEquals('bar', $headResponse2->getHeaderLine('X-HashTest'));
-        $this->assertContextCache($headResponse2->getHeaderLine('X-HashCache'));
+        $this->assertEquals('bar', $headResponse2->getHeaderLine('HashTest'));
+        $this->assertContextCache($headResponse2->getHeaderLine('HashCache'));
         $this->assertHit($headResponse2);
     }
 
@@ -70,11 +70,11 @@ abstract class UserContextTestCase extends VarnishTestCase
     {
         $response1 = $this->getResponse('/user_context_anon.php');
         $this->assertEquals('anonymous', $response1->getBody());
-        $this->assertEquals('MISS', $response1->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $response1->getHeaderLine('HashCache'));
 
         $response1 = $this->getResponse('/user_context_anon.php', ['Cookie' => ['0=foo']]);
         $this->assertEquals('foo', (string) $response1->getBody());
-        $this->assertEquals('MISS', $response1->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $response1->getHeaderLine('HashCache'));
 
         $cachedResponse1 = $this->getResponse('/user_context_anon.php');
         $this->assertEquals('anonymous', (string) $cachedResponse1->getBody());
@@ -82,7 +82,7 @@ abstract class UserContextTestCase extends VarnishTestCase
 
         $cachedResponse2 = $this->getResponse('/user_context_anon.php', ['Cookie' => ['0=foo']]);
         $this->assertEquals('foo', (string) $cachedResponse2->getBody());
-        $this->assertContextCache($cachedResponse2->getHeaderLine('X-HashCache'));
+        $this->assertContextCache($cachedResponse2->getHeaderLine('HashCache'));
         $this->assertHit($cachedResponse2);
     }
 
@@ -102,12 +102,12 @@ abstract class UserContextTestCase extends VarnishTestCase
     {
         $response = $this->getResponse('/user_context.php', ['Cookie' => ['0=miam']]);
         $this->assertEquals(403, $response->getStatusCode());
-        $this->assertEquals('MISS', $response->getHeaderLine('X-HashCache'));
+        $this->assertEquals('MISS', $response->getHeaderLine('HashCache'));
         $this->assertEquals(403, $response->getStatusCode());
 
         $response = $this->getResponse('/user_context.php', ['Cookie' => ['0=miam']]);
         $this->assertEquals(403, $response->getStatusCode());
-        $this->assertContextCache($response->getHeaderLine('X-HashCache'));
+        $this->assertContextCache($response->getHeaderLine('HashCache'));
         $this->assertEquals(403, $response->getStatusCode());
     }
 }

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -63,7 +63,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
     {
         $purge = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface')
             ->shouldReceive('purge')->once()->with('/my/route', [])
-            ->shouldReceive('purge')->once()->with('/my/route', ['X-Test-Header' => 'xyz'])
+            ->shouldReceive('purge')->once()->with('/my/route', ['Test-Header' => 'xyz'])
             ->shouldReceive('flush')->once()
             ->getMock();
 
@@ -71,7 +71,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 
         $cacheInvalidator
             ->invalidatePath('/my/route')
-            ->invalidatePath('/my/route', ['X-Test-Header' => 'xyz'])
+            ->invalidatePath('/my/route', ['Test-Header' => 'xyz'])
             ->flush()
         ;
     }
@@ -94,7 +94,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
     public function testInvalidate()
     {
         $headers = [
-            'X-Header' => '^value.*$',
+            'Header' => '^value.*$',
             'Other-Header' => '^a|b|c$',
         ];
 

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -30,7 +30,7 @@ class SymfonyTest extends \PHPUnit_Framework_TestCase
         $symfony = new Symfony($ips, ['base_uri' => 'my_hostname.dev'], $this->client);
 
         $count = $symfony->purge('/url/one')
-            ->purge('/url/two', ['X-Foo' => 'bar'])
+            ->purge('/url/two', ['Foo' => 'bar'])
             ->flush()
         ;
         $this->assertEquals(2, $count);
@@ -45,9 +45,9 @@ class SymfonyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://127.0.0.1:8080/url/one', $requests[0]->getUri());
         $this->assertEquals('http://123.123.123.2/url/one', $requests[1]->getUri());
         $this->assertEquals('http://127.0.0.1:8080/url/two', $requests[2]->getUri());
-        $this->assertEquals('bar', $requests[2]->getHeaderLine('X-Foo'));
+        $this->assertEquals('bar', $requests[2]->getHeaderLine('Foo'));
         $this->assertEquals('http://123.123.123.2/url/two', $requests[3]->getUri());
-        $this->assertEquals('bar', $requests[3]->getHeaderLine('X-Foo'));
+        $this->assertEquals('bar', $requests[3]->getHeaderLine('Foo'));
     }
 
     public function testRefresh()

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -31,9 +31,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $requests);
         $this->assertEquals('BAN', $requests[0]->getMethod());
 
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Host'));
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Url'));
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Content-Type'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Host'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Url'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Content-Type'));
         $this->assertEquals('fos.lo', $requests[0]->getHeaderLine('Host'));
     }
 
@@ -46,9 +46,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $requests);
         $this->assertEquals('BAN', $requests[0]->getMethod());
 
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Host'));
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Url'));
-        $this->assertEquals('.*', $requests[0]->getHeaderLine('X-Content-Type'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Host'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Url'));
+        $this->assertEquals('.*', $requests[0]->getHeaderLine('Content-Type'));
 
         // Ensure host header matches the Varnish server one.
         $this->assertEquals('http://127.0.0.1:123/', $requests[0]->getUri());
@@ -83,9 +83,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $requests);
         $this->assertEquals('BAN', $requests[0]->getMethod());
 
-        $this->assertEquals('^(fos.lo|fos2.lo)$', $requests[0]->getHeaderLine('X-Host'));
-        $this->assertEquals('/articles/.*', $requests[0]->getHeaderLine('X-Url'));
-        $this->assertEquals('text/html', $requests[0]->getHeaderLine('X-Content-Type'));
+        $this->assertEquals('^(fos.lo|fos2.lo)$', $requests[0]->getHeaderLine('Host'));
+        $this->assertEquals('/articles/.*', $requests[0]->getHeaderLine('Url'));
+        $this->assertEquals('text/html', $requests[0]->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -113,7 +113,7 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $requests);
         $this->assertEquals('BAN', $requests[0]->getMethod());
 
-        $this->assertEquals('(post\-1|post\-type\-3)(,.+)?$', $requests[0]->getHeaderLine('X-Cache-Tags'));
+        $this->assertEquals('(post\-1|post\-type\-3)(,.+)?$', $requests[0]->getHeaderLine('Cache-Tags'));
         $this->assertEquals('fos.lo', $requests[0]->getHeaderLine('Host'));
 
         // That default BANs is taken into account also for tags as they are powered by BAN in this client.
@@ -123,7 +123,7 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testTagsHeadersEscapingAndCustomHeader()
     {
-        $varnish = new Varnish(['127.0.0.1:123'], ['base_uri' => 'fos.lo', 'tags_header' => 'X-Tags-TRex'], $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], ['base_uri' => 'fos.lo', 'tags_header' => 'Tags-TRex'], $this->client);
         $varnish->invalidateTags(['post-1', 'post,type-3'])->flush();
 
         $requests = $this->getRequests();
@@ -131,7 +131,7 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $requests);
         $this->assertEquals('BAN', $requests[0]->getMethod());
 
-        $this->assertEquals('(post\-1|post_type\-3)(,.+)?$', $requests[0]->getHeaderLine('X-Tags-TRex'));
+        $this->assertEquals('(post\-1|post_type\-3)(,.+)?$', $requests[0]->getHeaderLine('Tags-TRex'));
         $this->assertEquals('fos.lo', $requests[0]->getHeaderLine('Host'));
     }
 
@@ -141,7 +141,7 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $varnish = new Varnish($ips, ['base_uri' => 'my_hostname.dev'], $this->client);
 
         $count = $varnish->purge('/url/one')
-            ->purge('/url/two', ['X-Foo' => 'bar'])
+            ->purge('/url/two', ['Foo' => 'bar'])
             ->flush()
         ;
         $this->assertEquals(2, $count);
@@ -156,9 +156,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://127.0.0.1:8080/url/one', $requests[0]->getUri());
         $this->assertEquals('http://123.123.123.2/url/one', $requests[1]->getUri());
         $this->assertEquals('http://127.0.0.1:8080/url/two', $requests[2]->getUri());
-        $this->assertEquals('bar', $requests[2]->getHeaderLine('X-Foo'));
+        $this->assertEquals('bar', $requests[2]->getHeaderLine('Foo'));
         $this->assertEquals('http://123.123.123.2/url/two', $requests[3]->getUri());
-        $this->assertEquals('bar', $requests[3]->getHeaderLine('X-Foo'));
+        $this->assertEquals('bar', $requests[3]->getHeaderLine('Foo'));
     }
 
     public function testRefresh()
@@ -183,9 +183,9 @@ class VarnishTest extends \PHPUnit_Framework_TestCase
 
     public function testAdditionalContructorOptions()
     {
-        $varnish = new Varnish(['127.0.0.1:123'], ['base_uri' => 'fos.lo', 'tags_header' => 'X-Tags-TRex', 'header_length' => 8000], $this->client);
+        $varnish = new Varnish(['127.0.0.1:123'], ['base_uri' => 'fos.lo', 'tags_header' => 'Tags-TRex', 'header_length' => 8000], $this->client);
 
-        $this->assertEquals('X-Tags-TRex', $varnish->getTagsHeaderName());
+        $this->assertEquals('Tags-TRex', $varnish->getTagsHeaderName());
         $this->assertEquals(8000, $varnish->getHeaderLength());
     }
 

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -38,7 +38,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
         $ttlListener = new CustomTtlListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Reverse-Proxy-TTL' => '120',
+            'Reverse-Proxy-TTL' => '120',
             'Cache-Control' => 's-maxage=60, max-age=30',
         ));
         $event = new CacheEvent($this->kernel, $request, $response);
@@ -56,7 +56,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
         $ttlListener = new CustomTtlListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Reverse-Proxy-TTL' => '120',
+            'Reverse-Proxy-TTL' => '120',
             'Cache-Control' => 'max-age=30',
         ));
         $event = new CacheEvent($this->kernel, $request, $response);
@@ -74,7 +74,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
         $ttlListener = new CustomTtlListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Reverse-Proxy-TTL' => '120',
+            'Reverse-Proxy-TTL' => '120',
             'Cache-Control' => 's-maxage=120, max-age=30',
             CustomTtlListener::SMAXAGE_BACKUP => '60',
         ));
@@ -86,7 +86,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
         $this->assertTrue($response->headers->hasCacheControlDirective('s-maxage'));
         $this->assertSame('60', $response->headers->getCacheControlDirective('s-maxage'));
-        $this->assertFalse($response->headers->has('X-Reverse-Proxy-TTL'));
+        $this->assertFalse($response->headers->has('Reverse-Proxy-TTL'));
         $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
     }
 
@@ -95,7 +95,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
         $ttlListener = new CustomTtlListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Reverse-Proxy-TTL' => '120',
+            'Reverse-Proxy-TTL' => '120',
             'Cache-Control' => 's-maxage: 120, max-age: 30',
             CustomTtlListener::SMAXAGE_BACKUP => 'false',
         ));
@@ -106,7 +106,7 @@ class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
         $this->assertFalse($response->headers->hasCacheControlDirective('s_maxage'));
-        $this->assertFalse($response->headers->has('X-Reverse-Proxy-TTL'));
+        $this->assertFalse($response->headers->has('Reverse-Proxy-TTL'));
         $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
     }
 }

--- a/tests/Unit/SymfonyCache/DebugListenerTest.php
+++ b/tests/Unit/SymfonyCache/DebugListenerTest.php
@@ -38,7 +38,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $debugListener = new DebugListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Symfony-Cache' => '... fresh ...',
+            'Symfony-Cache' => '... fresh ...',
         ));
         $event = new CacheEvent($this->kernel, $request, $response);
 
@@ -46,7 +46,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
-        $this->assertSame('HIT', $response->headers->get('X-Cache'));
+        $this->assertSame('HIT', $response->headers->get('Cache'));
     }
 
     public function testDebugMiss()
@@ -54,7 +54,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $debugListener = new DebugListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Symfony-Cache' => '... miss ...',
+            'Symfony-Cache' => '... miss ...',
         ));
         $event = new CacheEvent($this->kernel, $request, $response);
 
@@ -62,7 +62,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
-        $this->assertSame('MISS', $response->headers->get('X-Cache'));
+        $this->assertSame('MISS', $response->headers->get('Cache'));
     }
 
     public function testDebugUndefined()
@@ -70,7 +70,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $debugListener = new DebugListener();
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, array(
-            'X-Symfony-Cache' => '... foobar ...',
+            'Symfony-Cache' => '... foobar ...',
         ));
         $event = new CacheEvent($this->kernel, $request, $response);
 
@@ -78,7 +78,7 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
-        $this->assertSame('UNDETERMINED', $response->headers->get('X-Cache'));
+        $this->assertSame('UNDETERMINED', $response->headers->get('Cache'));
     }
 
     public function testNoHeader()
@@ -92,6 +92,6 @@ class DebugListenerTest extends \PHPUnit_Framework_TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
-        $this->assertFalse($response->headers->has('X-Cache'));
+        $this->assertFalse($response->headers->has('Cache'));
     }
 }


### PR DESCRIPTION
fix #279

[rfc6648](http://tools.ietf.org/html/rfc6648) says to not prefix custom headers with x-. this PR removes all x- prefixes from default header names we use in this library.

X-Symfony-Cache is done by symfony, not by us.

Question: Is this a good idea and makes the library cleaner, or a pedantic change that is an unnecessary BC break and leads to tons of confusion? Upgrading applications have to also change all their VCL or nginx configuration or will end with broken systems.