### PR TITLE
adds a noop client which implements all interfaces but …

### DIFF
--- a/src/ProxyClient/Noop.php
+++ b/src/ProxyClient/Noop.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\ProxyClient;
+
+use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
+use Http\Message\MessageFactory;
+
+/**
+ * Class Noop
+ *
+ * This is a no operation client, its only purpose is to provide an implementation for use in an enviroments that
+ * have no proxy to use.
+ *
+ * @author Gavin Staniforth <gavin@gsdev.me>
+ */
+class Noop implements ProxyClientInterface, BanInterface, PurgeInterface, RefreshInterface, TagsInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function ban(array $headers)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function banPath($path, $contentType = null, $hosts = null)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidateTags(array $tags)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTagsHeaderValue(array $tags)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTagsHeaderName()
+    {
+        return 'X-Noop-Cache-Tags';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge($url, array $headers = [])
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh($url, array $headers = [])
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        return 0;
+    }
+}

--- a/src/ProxyClient/Noop.php
+++ b/src/ProxyClient/Noop.php
@@ -15,11 +15,8 @@ use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
 use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
-use Http\Message\MessageFactory;
 
 /**
- * Class Noop
- *
  * This is a no operation client, its only purpose is to provide an implementation for use in an enviroments that
  * have no proxy to use.
  *

--- a/tests/Unit/ProxyClient/NoopTest.php
+++ b/tests/Unit/ProxyClient/NoopTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\ProxyClient;
+
+use FOS\HttpCache\ProxyClient\Noop;
+
+class NoopTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Noop
+     */
+    private $noop;
+
+    protected function setUp()
+    {
+        $this->noop = new Noop();
+    }
+
+    public function testBan()
+    {
+        $this->assertSame($this->noop, $this->noop->ban(['header-123']));
+    }
+
+    public function testInvalidateTags()
+    {
+        $this->assertSame($this->noop, $this->noop->invalidateTags(['tag123']));
+    }
+
+    public function testBanPath()
+    {
+        $this->assertSame($this->noop, $this->noop->banPath('/123'));
+    }
+
+    public function testFlush()
+    {
+        $this->assertTrue(is_int($this->noop->flush()));
+    }
+
+    public function testGetTagsHeaderName()
+    {
+        $this->assertEquals('X-Noop-Cache-Tags', $this->noop->getTagsHeaderName());
+    }
+
+    public function testGetTagsHeaderValue()
+    {
+        $this->assertTrue(is_array($this->noop->getTagsHeaderValue(['tag123'])));
+    }
+
+    public function testPurge()
+    {
+        $this->assertSame($this->noop, $this->noop->purge('/123', ['x-123' => 'yes']));
+    }
+
+    public function testRefresh()
+    {
+        $this->assertSame($this->noop, $this->noop->refresh('/123'));
+    }
+}


### PR DESCRIPTION
As discussed here https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/issues/293

Each method is implemented from the interfaces and follows the docblocks, also using a constructor similar to the abstract. I can't write any tests for this though as phpunit is not included within composer require-dev :O 