### PR TITLE
Updating dependencies, using discovery 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         "symfony/event-dispatcher": "^2.3||^3.0",
         "symfony/options-resolver": "^2.7||^3.0",
         "php-http/client-implementation": "^1.0.0",
-        "php-http/message": "^1.0.0"
+        "php-http/message": "^1.0.0",
+        "php-http/discovery": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.1",
         "monolog/monolog": "^1.0",
-        "php-http/discovery": "^1.0",
         "php-http/guzzle6-adapter": "^1.0.0",
         "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,11 @@
     "require-dev": {
         "mockery/mockery": "~0.9.1",
         "monolog/monolog": "^1.0",
-        "php-http/discovery": "~0.8",
+        "php-http/discovery": "^1.0",
         "php-http/guzzle6-adapter": "^1.0.0",
-        "php-http/mock-client": "~0.1",
+        "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
-        "puli/composer-plugin": "^1.0.0-beta9@beta",
         "phpunit/phpunit": "^4.5.0 || ^5.0.0 <5.4"
     },
     "suggest": {

--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -74,10 +74,6 @@ abstract class AbstractProxyClient implements ProxyClientInterface
         MessageFactory $messageFactory = null,
         UriFactory $uriFactory = null
     ) {
-        if ((!$httpClient || !$messageFactory || !$uriFactory) && !class_exists('Http\Discovery\HttpAsyncClientDiscovery')) {
-            throw new \LogicException('Either specify the client and the message and uri factories or include php-http/discovery in your project');
-        }
-
         if (!$httpClient) {
             $httpClient = HttpAsyncClientDiscovery::find();
         }


### PR DESCRIPTION
This will remove the dependency on Puli. The php-http/discovery library is very lightweight, we should consider moving it from require-dev to require. 

This will fix #268
