### PR TITLE
clean up event listener class naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 * Added support and documentation for setting a custom TTL specifically for the
   caching proxy.
 
+### Logging
+
+* BC BREAK: Renamed the log event listener from Logsubscriber to LogListener.
+
 ### Tagging
 
 * Abstracting tags by adding new `TagsInterface` for ProxyClients, as part of
@@ -29,7 +33,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 * Varnish configuration are now files that you can directly include from your
   .vcl and call custom functions to avoid copy-pasting VCL code.
-* Moved Varnish 4 and 5 configuration files from `resources/config/varnish-4/` 
+* Moved Varnish 4 and 5 configuration files from `resources/config/varnish-4/`
   to `resources/config/varnish/`.
 * Changed default Varnish version to 5.
 
@@ -40,7 +44,8 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 ### Symfony HttpCache
 
-* BC BREAK: Constructors for PurgeSubscriber and RefreshSubscriber now use an
+* BC BREAK: Renamed all event listeners to XxListener instead of XxSubscriber.
+* BC BREAK: Constructors for PurgeListener and RefreshListener now use an
   options array for customization.
 
 ### Testing

--- a/doc/cache-invalidator.rst
+++ b/doc/cache-invalidator.rst
@@ -224,7 +224,7 @@ So, to catch exceptions::
 Logging errors
 ~~~~~~~~~~~~~~
 
-You can log any exceptions with the help of the ``LogSubscriber`` provided in
+You can log any exceptions with the help of the ``LogListener`` provided in
 this library. First construct a logger that implements
 ``\Psr\Log\LoggerInterface``. For instance, when using Monolog_::
 
@@ -233,12 +233,12 @@ this library. First construct a logger that implements
     $monolog = new Logger(...);
     $monolog->pushHandler(...);
 
-Then add the logger as a subscriber to the cache invalidator::
+Then add the logger as a listener to the cache invalidator::
 
-    use FOS\HttpCache\EventListener\LogSubscriber;
+    use FOS\HttpCache\EventListener\LogListener;
 
-    $subscriber = new LogSubscriber($monolog);
-    $cacheInvalidator->getEventDispatcher()->addSubscriber($subscriber);
+    $logListener = new LogListener($monolog);
+    $cacheInvalidator->getEventDispatcher()->addSubscriber($logListener);
 
 Now, if you flush the invalidator, errors will be logged::
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -40,7 +40,7 @@ trait ``FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache``::
         use EventDispatchingHttpCache;
 
         /**
-         * Made public to allow event subscribers to do refresh operations.
+         * Made public to allow event listeners to do refresh operations.
          *
          * {@inheritDoc}
          */
@@ -86,14 +86,14 @@ the listeners you need there::
 
     use FOS\HttpCache\SymfonyCache\DebugListener();
     use FOS\HttpCache\SymfonyCache\CustomTtlListener();
-    use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
-    use FOS\HttpCache\SymfonyCache\RefreshSubscriber;
-    use FOS\HttpCache\SymfonyCache\UserContextSubscriber;
+    use FOS\HttpCache\SymfonyCache\PurgeListener;
+    use FOS\HttpCache\SymfonyCache\RefreshListener;
+    use FOS\HttpCache\SymfonyCache\UserContextListener;
 
     // ...
 
     /**
-     * Overwrite constructor to register event subscribers for FOSHttpCache.
+     * Overwrite constructor to register event listeners for FOSHttpCache.
      */
     public function __construct(
         HttpKernelInterface $kernel,
@@ -104,9 +104,9 @@ the listeners you need there::
         parent::__construct($kernel, $store, $surrogate, $options);
 
         $this->addSubscriber(new CustomTtlListener());
-        $this->addSubscriber(new PurgeSubscriber());
-        $this->addSubscriber(new RefreshSubscriber());
-        $this->addSubscriber(new UserContextSubscriber());
+        $this->addSubscriber(new PurgeListener());
+        $this->addSubscriber(new RefreshListener());
+        $this->addSubscriber(new UserContextListener());
         if (isset($options['debug']) && $options['debug']) {
             $this->addSubscriber(new DebugListener());
         }
@@ -120,7 +120,7 @@ Purge
 ~~~~~
 
 To support :ref:`cache invalidation <cache invalidate>`, register the
-``PurgeSubscriber``. If the default settings are right for you, you don't
+``PurgeListener``. If the default settings are right for you, you don't
 need to do anything more.
 
 Purging is only allowed from the same machine by default. To purge data from
@@ -146,14 +146,14 @@ Refresh
 ~~~~~~~
 
 To support :ref:`cache refresh <cache refresh>`, register the
-``RefreshSubscriber``. You can pass the constructor an option to specify
+``RefreshListener``. You can pass the constructor an option to specify
 what clients are allowed to refresh cache entries. Refreshing is only allowed
 from the same machine by default. To refresh from other hosts, provide the
 IPs of the machines allowed to refresh, or provide a RequestMatcher that
 checks for an Authorization header or similar. *Only set one of
 ``client_ips`` or ``client_matcher``*.
 
-The refresh subscriber needs to access the ``HttpCache::fetch`` method which
+The refresh listener needs to access the ``HttpCache::fetch`` method which
 is protected on the base HttpCache class. The ``EventDispatchingHttpCache``
 exposes the method as public, but if you implement your own kernel, you need
 to overwrite the method to make it public.
@@ -174,7 +174,7 @@ User Context
 ~~~~~~~~~~~~
 
 To support :doc:`user context hashing <user-context>` you need to register the
-``UserContextSubscriber``. The user context is then automatically recognized
+``UserContextListener``. The user context is then automatically recognized
 based on session cookies or authorization headers. If the default settings are
 right for you, you don't need to do anything more. You can customize a number of
 options through the constructor:
@@ -230,9 +230,9 @@ options through the constructor:
 Cleaning the Cookie Header
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the UserContextSubscriber only sets the session cookie (according to
+By default, the UserContextListener only sets the session cookie (according to
 the ``session_name_prefix`` option) in the requests to the backend. If you need
-a different behavior, overwrite ``UserContextSubscriber::cleanupHashLookupRequest``
+a different behavior, overwrite ``UserContextListener::cleanupHashLookupRequest``
 with your own logic.
 
 .. _symfonycache_customttl:
@@ -242,11 +242,11 @@ Custom TTL
 
 .. include:: includes/custom-ttl.rst
 
-The ``CustomTtlSubscriber`` looks at a specific header to determine the TTL,
+The ``CustomTtlListener`` looks at a specific header to determine the TTL,
 preferring that over ``s-maxage``. The default header is ``X-Reverse-Proxy-TTL``
-but you can customize that in the subscriber constructor::
+but you can customize that in the listener constructor::
 
-    new CustomTtlSubscriber('My-TTL-Header');
+    new CustomTtlListener('My-TTL-Header');
 
 The custom header is removed before sending the response to the client.
 

--- a/src/EventListener/LogListener.php
+++ b/src/EventListener/LogListener.php
@@ -17,7 +17,10 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LogSubscriber implements EventSubscriberInterface
+/**
+ * Log when the caching proxy client can't  send requests to the caching server.
+ */
+class LogListener implements EventSubscriberInterface
 {
     /**
      * @var LoggerInterface

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -13,7 +13,7 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
-use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
 
 /**
  * Symfony HttpCache invalidator.
@@ -53,7 +53,7 @@ class Symfony extends HttpProxyClient implements PurgeInterface, RefreshInterfac
     {
         $resolver = parent::configureOptions();
         $resolver->setDefaults([
-            'purge_method' => PurgeSubscriber::DEFAULT_PURGE_METHOD,
+            'purge_method' => PurgeListener::DEFAULT_PURGE_METHOD,
         ]);
 
         return $resolver;

--- a/src/SymfonyCache/AccessControlledListener.php
+++ b/src/SymfonyCache/AccessControlledListener.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * {@inheritdoc}
  */
-abstract class AccessControlledSubscriber implements EventSubscriberInterface
+abstract class AccessControlledListener implements EventSubscriberInterface
 {
     /**
      * @var RequestMatcher
@@ -33,7 +33,7 @@ abstract class AccessControlledSubscriber implements EventSubscriberInterface
     private $clientMatcher;
 
     /**
-     * When creating this subscriber, you can configure a number of options.
+     * When creating this event listener, you can configure a number of options.
      *
      * - client_matcher: RequestMatcherInterface to identify clients that are allowed to send request.
      * - client_ips:     IP or array of IPs of clients that are allowed to send requests.

--- a/src/SymfonyCache/CacheInvalidationInterface.php
+++ b/src/SymfonyCache/CacheInvalidationInterface.php
@@ -26,7 +26,7 @@ interface CacheInvalidationInterface extends HttpKernelInterface
      *
      * This methods is triggered when the cache missed or a reload is required.
      *
-     * This method is present on HttpCache but must be public to allow event subscribers to do
+     * This method is present on HttpCache but must be public to allow event listeners to do
      * refresh operations.
      *
      * @param Request $request A Request instance

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * public does not satisfy the interface for whatever reason. See also
  * http://stackoverflow.com/questions/31877844/php-trait-exposing-a-method-and-interfaces )
  *
- * CacheInvalidator kernels support event subscribers that can act on the
+ * CacheInvalidator kernels support event listeners that can act on the
  * events defined in FOS\HttpCache\SymfonyCache\Events and may alter the
  * request flow.
  *
@@ -62,7 +62,7 @@ trait EventDispatchingHttpCache
     }
 
     /**
-     * Add subscriber.
+     * Add an event subscriber.
      *
      * @param EventSubscriberInterface $subscriber
      */

--- a/src/SymfonyCache/PurgeListener.php
+++ b/src/SymfonyCache/PurgeListener.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * {@inheritdoc}
  */
-class PurgeSubscriber extends AccessControlledSubscriber
+class PurgeListener extends AccessControlledListener
 {
     const DEFAULT_PURGE_METHOD = 'PURGE';
 
@@ -33,15 +33,15 @@ class PurgeSubscriber extends AccessControlledSubscriber
     private $purgeMethod;
 
     /**
-     * When creating the purge subscriber, you can configure an additional option.
+     * When creating the purge listener, you can configure an additional option.
      *
-     * - purge_method:         HTTP method that identifies purge requests.
+     * - purge_method: HTTP method that identifies purge requests.
      *
      * @param array $options Options to overwrite the default options
      *
      * @throws \InvalidArgumentException if unknown keys are found in $options
      *
-     * @see AccessControlledSubscriber::__construct
+     * @see AccessControlledListener::__construct
      */
     public function __construct(array $options = [])
     {

--- a/src/SymfonyCache/RefreshListener.php
+++ b/src/SymfonyCache/RefreshListener.php
@@ -21,7 +21,7 @@ namespace FOS\HttpCache\SymfonyCache;
  *
  * {@inheritdoc}
  */
-class RefreshSubscriber extends AccessControlledSubscriber
+class RefreshListener extends AccessControlledListener
 {
     /**
      * {@inheritdoc}

--- a/src/SymfonyCache/UserContextListener.php
+++ b/src/SymfonyCache/UserContextListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * {@inheritdoc}
  */
-class UserContextSubscriber implements EventSubscriberInterface
+class UserContextListener implements EventSubscriberInterface
 {
     /**
      * The options configured in the constructor argument or default values.
@@ -41,7 +41,7 @@ class UserContextSubscriber implements EventSubscriberInterface
     private $userHash;
 
     /**
-     * When creating this subscriber, you can configure a number of options.
+     * When creating this listener, you can configure a number of options.
      *
      * - anonymous_hash:          Hash used for anonymous user.
      * - user_hash_accept_header: Accept header value to be used to request the user hash to the

--- a/src/Test/EventDispatchingHttpCacheTestCase.php
+++ b/src/Test/EventDispatchingHttpCacheTestCase.php
@@ -107,8 +107,8 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $response = new Response();
 
         $httpCache = $this->getHttpCachePartialMock(['lookup']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->any())
             ->method('lookup')
@@ -117,8 +117,8 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         ;
 
         $this->assertSame($response, $httpCache->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch));
-        $this->assertEquals(1, $subscriber->preHandleCalls);
-        $this->assertEquals(1, $subscriber->postHandleCalls);
+        $this->assertEquals(1, $testListener->preHandleCalls);
+        $this->assertEquals(1, $testListener->postHandleCalls);
     }
 
     /**
@@ -133,17 +133,17 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $response = new Response();
 
         $httpCache = $this->getHttpCachePartialMock(['lookup']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $subscriber->preHandleResponse = $response;
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $testListener->preHandleResponse = $response;
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->never())
             ->method('lookup')
         ;
 
         $this->assertSame($response, $httpCache->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch));
-        $this->assertEquals(1, $subscriber->preHandleCalls);
-        $this->assertEquals(1, $subscriber->postHandleCalls);
+        $this->assertEquals(1, $testListener->preHandleCalls);
+        $this->assertEquals(1, $testListener->postHandleCalls);
     }
 
     /**
@@ -159,9 +159,9 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $postResponse = new Response();
 
         $httpCache = $this->getHttpCachePartialMock(['lookup']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $subscriber->postHandleResponse = $postResponse;
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $testListener->postHandleResponse = $postResponse;
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->any())
             ->method('lookup')
@@ -170,8 +170,8 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         ;
 
         $this->assertSame($postResponse, $httpCache->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch));
-        $this->assertEquals(1, $subscriber->preHandleCalls);
-        $this->assertEquals(1, $subscriber->postHandleCalls);
+        $this->assertEquals(1, $testListener->preHandleCalls);
+        $this->assertEquals(1, $testListener->postHandleCalls);
     }
 
     /**
@@ -187,18 +187,18 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $postResponse = new Response();
 
         $httpCache = $this->getHttpCachePartialMock(['lookup']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $subscriber->preHandleResponse = $preResponse;
-        $subscriber->postHandleResponse = $postResponse;
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $testListener->preHandleResponse = $preResponse;
+        $testListener->postHandleResponse = $postResponse;
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->never())
             ->method('lookup')
         ;
 
         $this->assertSame($postResponse, $httpCache->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch));
-        $this->assertEquals(1, $subscriber->preHandleCalls);
-        $this->assertEquals(1, $subscriber->postHandleCalls);
+        $this->assertEquals(1, $testListener->preHandleCalls);
+        $this->assertEquals(1, $testListener->postHandleCalls);
     }
 
     /**
@@ -210,8 +210,8 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $response = new Response();
 
         $httpCache = $this->getHttpCachePartialMock();
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $httpCache->addSubscriber($testListener);
 
         $this->setStoreMock($httpCache, $request, $response);
 
@@ -219,7 +219,7 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $method = $refHttpCache->getMethod('store');
         $method->setAccessible(true);
         $method->invokeArgs($httpCache, [$request, $response]);
-        $this->assertEquals(1, $subscriber->preStoreCalls);
+        $this->assertEquals(1, $testListener->preStoreCalls);
     }
 
     /**
@@ -232,9 +232,9 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $preStoreResponse = new Response();
 
         $httpCache = $this->getHttpCachePartialMock();
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $subscriber->preStoreResponse = $preStoreResponse;
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $testListener->preStoreResponse = $preStoreResponse;
+        $httpCache->addSubscriber($testListener);
 
         $this->setStoreMock($httpCache, $request, $preStoreResponse);
 
@@ -242,7 +242,7 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $method = $refHttpCache->getMethod('store');
         $method->setAccessible(true);
         $method->invokeArgs($httpCache, [$request, $regularResponse]);
-        $this->assertEquals(1, $subscriber->preStoreCalls);
+        $this->assertEquals(1, $testListener->preStoreCalls);
     }
 
     /**
@@ -255,8 +255,8 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $response = new Response('', 500);
 
         $httpCache = $this->getHttpCachePartialMock(['pass']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->any())
             ->method('pass')
@@ -268,7 +268,7 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $method->setAccessible(true);
 
         $this->assertSame($response, $method->invokeArgs($httpCache, [$request, $catch]));
-        $this->assertEquals(1, $subscriber->preInvalidateCalls);
+        $this->assertEquals(1, $testListener->preInvalidateCalls);
     }
 
     /**
@@ -283,9 +283,9 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $response = new Response('', 400);
 
         $httpCache = $this->getHttpCachePartialMock(['pass']);
-        $subscriber = new TestSubscriber($this, $httpCache, $request);
-        $subscriber->preInvalidateResponse = $response;
-        $httpCache->addSubscriber($subscriber);
+        $testListener = new TestListener($this, $httpCache, $request);
+        $testListener->preInvalidateResponse = $response;
+        $httpCache->addSubscriber($testListener);
         $httpCache
             ->expects($this->never())
             ->method('pass')
@@ -295,11 +295,11 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
         $method->setAccessible(true);
 
         $this->assertSame($response, $method->invokeArgs($httpCache, [$request, $catch]));
-        $this->assertEquals(1, $subscriber->preInvalidateCalls);
+        $this->assertEquals(1, $testListener->preInvalidateCalls);
     }
 }
 
-class TestSubscriber implements EventSubscriberInterface
+class TestListener implements EventSubscriberInterface
 {
     /**
      * @var int Count how many times preHandle has been called

--- a/tests/Functional/Fixtures/Symfony/AppCache.php
+++ b/tests/Functional/Fixtures/Symfony/AppCache.php
@@ -17,9 +17,9 @@ use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use FOS\HttpCache\SymfonyCache\DebugListener;
-use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
-use FOS\HttpCache\SymfonyCache\RefreshSubscriber;
-use FOS\HttpCache\SymfonyCache\UserContextSubscriber;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\RefreshListener;
+use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpCache\SurrogateInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -33,16 +33,16 @@ class AppCache extends HttpCache implements CacheInvalidationInterface
         parent::__construct($kernel, $store, $surrogate, $options);
 
         $this->addSubscriber(new CustomTtlListener());
-        $this->addSubscriber(new PurgeSubscriber(['purge_method' => 'NOTIFY']));
-        $this->addSubscriber(new RefreshSubscriber());
-        $this->addSubscriber(new UserContextSubscriber());
+        $this->addSubscriber(new PurgeListener(['purge_method' => 'NOTIFY']));
+        $this->addSubscriber(new RefreshListener());
+        $this->addSubscriber(new UserContextListener());
         if (isset($options['debug']) && $options['debug']) {
             $this->addSubscriber(new DebugListener());
         }
     }
 
     /**
-     * Made public to allow event subscribers to do refresh operations.
+     * Made public to allow event listeners to do refresh operations.
      *
      * {@inheritdoc}
      */

--- a/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
+++ b/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
@@ -15,9 +15,9 @@ use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use FOS\HttpCache\SymfonyCache\DebugListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
-use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
-use FOS\HttpCache\SymfonyCache\RefreshSubscriber;
-use FOS\HttpCache\SymfonyCache\UserContextSubscriber;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\RefreshListener;
+use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
@@ -29,7 +29,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSubscribers()
+    public function testEventListeners()
     {
         $request = new Request();
         $expectedResponse = new Response();
@@ -48,9 +48,9 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
         $kernel = new AppCache($httpKernel, $store);
         $kernel->addSubscriber(new CustomTtlListener());
         $kernel->addSubscriber(new DebugListener());
-        $kernel->addSubscriber(new PurgeSubscriber());
-        $kernel->addSubscriber(new RefreshSubscriber());
-        $kernel->addSubscriber(new UserContextSubscriber());
+        $kernel->addSubscriber(new PurgeListener());
+        $kernel->addSubscriber(new RefreshListener());
+        $kernel->addSubscriber(new UserContextListener());
 
         $response = $kernel->handle($request);
         $this->assertSame($expectedResponse, $response);
@@ -63,7 +63,7 @@ class AppCache extends HttpCache implements CacheInvalidationInterface
     use EventDispatchingHttpCache;
 
     /**
-     * Made public to allow event subscribers to do refresh operations.
+     * Made public to allow event listeners to do refresh operations.
      *
      * {@inheritdoc}
      */

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit;
 
 use FOS\HttpCache\CacheInvalidator;
-use FOS\HttpCache\EventListener\LogSubscriber;
+use FOS\HttpCache\EventListener\LogListener;
 use FOS\HttpCache\Exception\ExceptionCollection;
 use FOS\HttpCache\Exception\ProxyResponseException;
 use FOS\HttpCache\Exception\ProxyUnreachableException;
@@ -237,7 +237,7 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $cacheInvalidator->getEventDispatcher()->addSubscriber(new LogSubscriber($logger));
+        $cacheInvalidator->getEventDispatcher()->addSubscriber(new LogListener($logger));
 
         $cacheInvalidator
             ->flush()

--- a/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
+++ b/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
@@ -33,7 +33,7 @@ class AppCache extends HttpCache implements CacheInvalidationInterface
     use EventDispatchingHttpCache;
 
     /**
-     * Made public to allow event subscribers to do refresh operations.
+     * Made public to allow event listeners to do refresh operations.
      *
      * {@inheritdoc}
      */

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -13,14 +13,14 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
-use FOS\HttpCache\SymfonyCache\PurgeSubscriber;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
 use Mockery\MockInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 
-class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
+class PurgeListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * This tests a sanity check in the AbstractControlledListener.
@@ -30,7 +30,7 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorOverspecified()
     {
-        new PurgeSubscriber([
+        new PurgeListener([
             'client_matcher' => new RequestMatcher('/forbidden'),
             'client_ips' => ['1.2.3.4'],
         ]);
@@ -47,11 +47,11 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $kernel = $this->getKernelMock($store);
 
-        $purgeSubscriber = new PurgeSubscriber();
+        $purgeListener = new PurgeListener();
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($kernel, $request);
 
-        $purgeSubscriber->handlePurge($event);
+        $purgeListener->handlePurge($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -69,11 +69,11 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $kernel = $this->getKernelMock($store);
 
-        $purgeSubscriber = new PurgeSubscriber();
+        $purgeListener = new PurgeListener();
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($kernel, $request);
 
-        $purgeSubscriber->handlePurge($event);
+        $purgeListener->handlePurge($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -85,11 +85,11 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
         $kernel = $this->getUnusedKernelMock();
 
         $matcher = new RequestMatcher('/forbidden');
-        $purgeSubscriber = new PurgeSubscriber(['client_matcher' => $matcher]);
+        $purgeListener = new PurgeListener(['client_matcher' => $matcher]);
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($kernel, $request);
 
-        $purgeSubscriber->handlePurge($event);
+        $purgeListener->handlePurge($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -100,11 +100,11 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $kernel = $this->getUnusedKernelMock();
 
-        $purgeSubscriber = new PurgeSubscriber(['client_ips' => '1.2.3.4']);
+        $purgeListener = new PurgeListener(['client_ips' => '1.2.3.4']);
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($kernel, $request);
 
-        $purgeSubscriber->handlePurge($event);
+        $purgeListener->handlePurge($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -112,7 +112,7 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Configuring the method to something else should make this subscriber skip the request.
+     * Configuring the method to something else should make this listener skip the request.
      */
     public function testOtherMethod()
     {
@@ -121,14 +121,14 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
             ->shouldNotReceive('isRequestAllowed')
             ->getMock();
 
-        $purgeSubscriber = new PurgeSubscriber([
+        $purgeListener = new PurgeListener([
             'client_matcher' => $matcher,
             'purge_method' => 'FOO',
         ]);
         $request = Request::create('http://example.com/foo', 'PURGE');
         $event = new CacheEvent($kernel, $request);
 
-        $purgeSubscriber->handlePurge($event);
+        $purgeListener->handlePurge($event);
         $this->assertNull($event->getResponse());
     }
 
@@ -138,7 +138,7 @@ class PurgeSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new PurgeSubscriber(['stuff' => '1.2.3.4']);
+        new PurgeListener(['stuff' => '1.2.3.4']);
     }
 
     /**

--- a/tests/Unit/SymfonyCache/RefreshListenerTest.php
+++ b/tests/Unit/SymfonyCache/RefreshListenerTest.php
@@ -13,12 +13,12 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
-use FOS\HttpCache\SymfonyCache\RefreshSubscriber;
+use FOS\HttpCache\SymfonyCache\RefreshListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 
-class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
+class RefreshListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var CacheInvalidationInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -43,8 +43,8 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($response))
         ;
 
-        $refreshSubscriber = new RefreshSubscriber();
-        $refreshSubscriber->handleRefresh($event);
+        $refreshListener = new RefreshListener();
+        $refreshListener->handleRefresh($event);
 
         $this->assertSame($response, $event->getResponse());
     }
@@ -56,12 +56,12 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
         ;
 
         $matcher = new RequestMatcher('/forbidden');
-        $refreshSubscriber = new RefreshSubscriber(['client_matcher' => $matcher]);
+        $refreshListener = new RefreshListener(['client_matcher' => $matcher]);
         $request = Request::create('http://example.com/foo');
         $request->headers->addCacheControlDirective('no-cache');
         $event = new CacheEvent($this->kernel, $request);
 
-        $refreshSubscriber->handleRefresh($event);
+        $refreshListener->handleRefresh($event);
 
         $this->assertNull($event->getResponse());
     }
@@ -72,17 +72,17 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('fetch')
         ;
 
-        $refreshSubscriber = new RefreshSubscriber(['client_ips' => '1.2.3.4']);
+        $refreshListener = new RefreshListener(['client_ips' => '1.2.3.4']);
         $request = Request::create('http://example.com/foo');
         $request->headers->addCacheControlDirective('no-cache');
         $event = new CacheEvent($this->kernel, $request);
 
-        $refreshSubscriber->handleRefresh($event);
+        $refreshListener->handleRefresh($event);
         $this->assertNull($event->getResponse());
     }
 
     /**
-     * Configuring the method to something else should make this subscriber skip the request.
+     * Configuring the method to something else should make this listener skip the request.
      */
     public function testUnsafe()
     {
@@ -90,12 +90,12 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('fetch')
         ;
 
-        $refreshSubscriber = new RefreshSubscriber();
+        $refreshListener = new RefreshListener();
         $request = Request::create('http://example.com/foo', 'POST');
         $request->headers->addCacheControlDirective('no-cache');
         $event = new CacheEvent($this->kernel, $request);
 
-        $refreshSubscriber->handleRefresh($event);
+        $refreshListener->handleRefresh($event);
 
         $this->assertNull($event->getResponse());
     }
@@ -109,11 +109,11 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('fetch')
         ;
 
-        $refreshSubscriber = new RefreshSubscriber();
+        $refreshListener = new RefreshListener();
         $request = Request::create('http://example.com/foo');
         $event = new CacheEvent($this->kernel, $request);
 
-        $refreshSubscriber->handleRefresh($event);
+        $refreshListener->handleRefresh($event);
 
         $this->assertNull($event->getResponse());
     }
@@ -124,6 +124,6 @@ class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new RefreshSubscriber(['stuff' => '1.2.3.4']);
+        new RefreshListener(['stuff' => '1.2.3.4']);
     }
 }

--- a/tests/Unit/SymfonyCache/UserContextListenerTest.php
+++ b/tests/Unit/SymfonyCache/UserContextListenerTest.php
@@ -13,12 +13,12 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
-use FOS\HttpCache\SymfonyCache\UserContextSubscriber;
+use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Mockery\MockInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
+class UserContextListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var CacheInvalidationInterface|MockInterface
@@ -31,17 +31,17 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * UserContextSubscriber default options to simulate the correct headers.
+     * UserContextListener default options to simulate the correct headers.
      *
      * @return array
      */
     public function provideConfigOptions()
     {
-        $subscriber = new UserContextSubscriber();
-        $ref = new \ReflectionObject($subscriber);
+        $userContextListener = new UserContextListener();
+        $ref = new \ReflectionObject($userContextListener);
         $prop = $ref->getProperty('options');
         $prop->setAccessible(true);
-        $options = $prop->getValue($subscriber);
+        $options = $prop->getValue($userContextListener);
 
         $custom = [
             'user_hash_uri' => '/test-uri',
@@ -61,13 +61,13 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateUserHashNotAllowed($arg, $options)
     {
-        $userContextSubscriber = new UserContextSubscriber($arg);
+        $userContextListener = new UserContextListener($arg);
 
         $request = new Request();
         $request->headers->set('accept', $options['user_hash_accept_header']);
         $event = new CacheEvent($this->kernel, $request);
 
-        $userContextSubscriber->preHandle($event);
+        $userContextListener->preHandle($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -79,13 +79,13 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPassingUserHashNotAllowed($arg, $options)
     {
-        $userContextSubscriber = new UserContextSubscriber($arg);
+        $userContextListener = new UserContextListener($arg);
 
         $request = new Request();
         $request->headers->set($options['user_hash_header'], 'foo');
         $event = new CacheEvent($this->kernel, $request);
 
-        $userContextSubscriber->preHandle($event);
+        $userContextListener->preHandle($event);
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
@@ -97,13 +97,13 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testUserHashAnonymous($arg, $options)
     {
-        $userContextSubscriber = new UserContextSubscriber($arg);
+        $userContextListener = new UserContextListener($arg);
 
         $request = new Request();
 
         $event = new CacheEvent($this->kernel, $request);
 
-        $userContextSubscriber->preHandle($event);
+        $userContextListener->preHandle($event);
         $response = $event->getResponse();
 
         $this->assertNull($response);
@@ -116,7 +116,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testUserHashUserWithSession($arg, $options)
     {
-        $userContextSubscriber = new UserContextSubscriber($arg);
+        $userContextListener = new UserContextListener($arg);
 
         $sessionId1 = 'my_session_id';
         $sessionId2 = 'another_session_id';
@@ -168,7 +168,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $event = new CacheEvent($kernel, $request);
 
-        $userContextSubscriber->preHandle($event);
+        $userContextListener->preHandle($event);
         $response = $event->getResponse();
 
         $this->assertNull($response);
@@ -181,7 +181,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testUserHashUserWithAuthorizationHeader($arg, $options)
     {
-        $userContextSubscriber = new UserContextSubscriber($arg);
+        $userContextListener = new UserContextListener($arg);
 
         // The foo cookie should not be available in the eventual hash request anymore
         $request = Request::create('/foo', 'GET', [], ['foo' => 'bar'], [], ['HTTP_AUTHORIZATION' => 'foo']);
@@ -220,7 +220,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $event = new CacheEvent($kernel, $request);
 
-        $userContextSubscriber->preHandle($event);
+        $userContextListener->preHandle($event);
         $response = $event->getResponse();
 
         $this->assertNull($response);
@@ -234,6 +234,6 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConfiguration()
     {
-        new UserContextSubscriber(['foo' => 'bar']);
+        new UserContextListener(['foo' => 'bar']);
     }
 }


### PR DESCRIPTION
event listeners implementing the EventSubscriberInterface are still event listeners and should be named accordingly