### PR TITLE
Simplify hits counting

### DIFF
--- a/resources/config/varnish-3/fos_debug.vcl
+++ b/resources/config/varnish-3/fos_debug.vcl
@@ -8,7 +8,7 @@
  */
 
 sub fos_debug_deliver {
-    # Add extra headers if debugging is enabled
+    # Add X-Cache header if debugging is enabled
     if (resp.http.X-Cache-Debug) {
         if (obj.hits > 0) {
             set resp.http.X-Cache = "HIT";

--- a/resources/config/varnish/fos_debug.vcl
+++ b/resources/config/varnish/fos_debug.vcl
@@ -8,12 +8,9 @@
  */
 
 sub fos_debug_deliver {
-    # Add extra headers if debugging is enabled
-    # In Varnish 4 the obj.hits counter behaviour has changed, so we use a
-    # different method: if X-Varnish contains only 1 id, we have a miss, if it
-    # contains more (and therefore a space), we have a hit.
+    # Add X-Cache header if debugging is enabled
     if (resp.http.X-Cache-Debug) {
-        if (resp.http.X-Varnish ~ " ") {
+        if (obj.hits > 0) {
             set resp.http.X-Cache = "HIT";
         } else {
             set resp.http.X-Cache = "MISS";


### PR DESCRIPTION
With Varnish 4.0, the simple obj.hits stopped working and we had to resort to counting the number of spaces in X-Varnish. At least from Varnish 4.0.3 onwards, obj.hits works as it did in Varnish 3.

See also https://github.com/FriendsOfSymfony/FOSHttpCache/pull/173#issuecomment-255974274.