### PR TITLE
also expose the addListener method of the event dispatcher to the HttpCache trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 * BC BREAK: Renamed all event listeners to XxListener instead of XxSubscriber.
 * BC BREAK: Constructors for PurgeListener and RefreshListener now use an
   options array for customization.
+* Provide a trait for the event dispatching kernel, instead of a base class.
+  The trait offers both the addSubscriber and the addListener methods.
 
 ### Testing
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -50,14 +50,15 @@ trait ``FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache``::
         }
     }
 
-The trait is adding events before and/or after kernel methods to let the
-listeners interfere. If you need to overwrite core ``HttpCache`` functionality
-in your kernel, one option is to provide your own event listeners. If you need
-to implement functionality directly on the methods, be careful to always call
-the trait methods rather than going directly to the parent, or events will not
-be triggered anymore. You might also need to copy a method from the trait and
-add your own logic between the events to not be too early or too late for the
-event.
+The trait adds the ``addSubscriber`` and ``addListener`` methods as defined in
+the ``EventDispatcherInterface`` to your cache kernel. In addition, it triggers
+events before and/or after kernel methods to let the listeners interact. If you
+need to overwrite core ``HttpCache`` functionality in your kernel, you can
+provide your own event listeners. If you need to implement functionality
+directly on the methods, be careful to always call the trait methods rather
+than going directly to the parent, or events will not be triggered anymore. You
+might also need to copy a method from the trait and add your own logic between
+the events to not be too early or too late for the event.
 
 When starting to extend your ``AppCache``, it is recommended to use the
 ``EventDispatchingHttpCacheTestCase`` to run tests with your kernel to be sure

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -64,11 +64,21 @@ trait EventDispatchingHttpCache
     /**
      * Add an event subscriber.
      *
-     * @param EventSubscriberInterface $subscriber
+     * @see EventDispatcherInterface::addSubscriber
      */
     public function addSubscriber(EventSubscriberInterface $subscriber)
     {
         $this->getEventDispatcher()->addSubscriber($subscriber);
+    }
+
+    /**
+     * Add an event listener to this HttpCache.
+     *
+     * @see EventDispatcherInterface::addListener
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        $this->getEventDispatcher()->addListener($eventName, $listener, $priority);
     }
 
     /**


### PR DESCRIPTION
while we only use event subscribers, it makes sense to support other event listeners as well.