### PR TITLE
Bump php requirements to PHP 5.6 for 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ group: edge
 language: php
 
 php:
-  - 5.5
   - 5.6
 # broken with puli discovery  - hhvm
   - 7.0
@@ -14,7 +13,7 @@ env:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: SYMFONY_VERSION=2.7.* VARNISH_VERSION=3.0 COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0
       env: VARNISH_VERSION=4.1

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.5.9||^7.0.0",
+        "php": "^5.6||^7.0",
         "symfony/event-dispatcher": "^2.3||^3.0",
         "symfony/options-resolver": "^2.7||^3.0",
         "php-http/client-implementation": "^1.0.0",


### PR DESCRIPTION
Like Twig 2.0 [just did this week](https://github.com/twigphp/Twig/commit/af3b0a550c77b16fb6e9679ce6cc147d35888d04), it makes sense to drop PHP 5.5 support as it is EOL. 5.6 on the other hand is supported until 2018, and is the newest PHP version currently available on Debian/RHEL.