### PR TITLE
Remove Interface suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 ### PHP
 
 * Raised minimum PHP version to 5.5.
+* **BC break:** Removed the `Interface` suffix from all interfaces.
 
 ### HTTP
 
@@ -24,6 +25,11 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 * **BC break:** Renamed the log event listener from `LogSubscriber` to 
   `LogListener`.
+  
+### Proxy clients
+
+* **BC break**: Renamed the `Ban`, `Purge`, `Refresh` and `Tag` interfaces to 
+  `BanCapable`, `PurgeCapable`, `RefreshCapable` and `TagCapable`.
 
 ### Tagging
 

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -183,7 +183,7 @@ to all proxy clients provided at creation time::
 
     $nginxClient = new Nginx($servers);
     $symfonyClient = new Symfony([...]);
-    // Expects an array of ProxyClientInterface in the constructor
+    // Expects an array of ProxyClient in the constructor
     $client = new MultiplexerClient([$nginxClient, $symfonyClient]);
 
 .. note::
@@ -202,14 +202,14 @@ The recommended usage of the proxy client is to create an instance of
 Implementation Notes
 --------------------
 
-Each client is an implementation of :source:`ProxyClientInterface <src/ProxyClient/ProxyClientInterface.php>`.
-All other interfaces, ``PurgeInterface``, ``RefreshInterface`` and ``BanInterface``
-extend this ``ProxyClientInterface``. So each client implements at least one of
-the three :ref:`invalidation methods <invalidation methods>` depending on the
-proxy server’s abilities. To interact with a proxy client directly, refer to the
-doc comments on the interfaces.
+Each client is an implementation of :source:`ProxyClient <src/ProxyClient/ProxyClient.php>`.
+All other interfaces, ``PurgeCapable``, ``RefreshCapable``, ``BanCapable`` and
+``TagCapable``, extend this ``ProxyClient``. So each client implements at least
+one of the three :ref:`invalidation methods <invalidation methods>` depending on
+the proxy server’s abilities. To interact with a proxy client directly, refer to
+the doc comments on the interfaces.
 
-The ``ProxyClientInterface`` has one method: ``flush()``. After collecting
+The ``ProxyClient`` has one method: ``flush()``. After collecting
 invalidation requests, ``flush()`` needs to be called to actually send the
 requests to the proxy server. This is on purpose: this way, we can send
 all requests together, reducing the performance impact of sending invalidation

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -15,11 +15,11 @@ Setup
     Make sure to :doc:`configure your proxy <proxy-configuration>` for tagging first.
 
 The response tagger is a decorator around a proxy client that implements
-the ``TagsInterface``, handling adding tags to responses::
+the ``TagCapable`` interface, handling adding tags to responses::
 
     use FOS\HttpCache\ResponseTagger;
 
-    // $proxyClient already created, implementing FOS\HttpCache\ProxyClient\Invalidation\TagsInterface
+    // $proxyClient already created, implementing FOS\HttpCache\ProxyClient\Invalidation\TagCapable
     $responseTagger = new ResponseTagger($proxyClient);
 
 .. _response_tagger_optional_parameters:

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -27,15 +27,15 @@ Using the trait
     The trait is available since version 2.0.0. Version 1.* of this library
     instead provided a base ``HttpCache`` class to extend.
 
-Your ``AppCache`` needs to implement ``CacheInvalidationInterface`` and use the
+Your ``AppCache`` needs to implement ``CacheInvalidation`` and use the
 trait ``FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache``::
 
-    use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+    use FOS\HttpCache\SymfonyCache\CacheInvalidation;
     use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 
-    class AppCache extends HttpCache implements CacheInvalidationInterface
+    class AppCache extends HttpCache implements CacheInvalidation
     {
         use EventDispatchingHttpCache;
 

--- a/doc/user-context.rst
+++ b/doc/user-context.rst
@@ -121,10 +121,10 @@ and updates that with parameters which influence the varied response.
 
 A provider that looks at whether the user is authenticated could look like this::
 
-    use FOS\HttpCache\UserContext\ContextProviderInterface;
+    use FOS\HttpCache\UserContext\ContextProvider;
     use FOS\HttpCache\UserContext\UserContext;
 
-    class IsAuthenticatedProvider implements ContextProviderInterface
+    class IsAuthenticatedProvider implements ContextProvider
     {
         protected $userService;
 

--- a/src/Exception/ExceptionCollection.php
+++ b/src/Exception/ExceptionCollection.php
@@ -15,7 +15,7 @@ namespace FOS\HttpCache\Exception;
  * A collection of exceptions that might occur during the flush operation of a
  * ProxyClientInterface implementation.
  */
-class ExceptionCollection extends \Exception implements \IteratorAggregate, \Countable, HttpCacheExceptionInterface
+class ExceptionCollection extends \Exception implements \IteratorAggregate, \Countable, HttpCacheException
 {
     private $exceptions = [];
 

--- a/src/Exception/HttpCacheException.php
+++ b/src/Exception/HttpCacheException.php
@@ -14,6 +14,6 @@ namespace FOS\HttpCache\Exception;
 /**
  * Common interface for all exceptions thrown by this library.
  */
-interface HttpCacheExceptionInterface
+interface HttpCacheException
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -14,6 +14,6 @@ namespace FOS\HttpCache\Exception;
 /**
  * Wrapping the base exception for FOSHttpCache.
  */
-class InvalidArgumentException extends \InvalidArgumentException implements HttpCacheExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements HttpCacheException
 {
 }

--- a/src/Exception/InvalidTagException.php
+++ b/src/Exception/InvalidTagException.php
@@ -14,6 +14,6 @@ namespace FOS\HttpCache\Exception;
 /**
  * Thrown during tagging with an empty value.
  */
-class InvalidTagException extends \InvalidArgumentException implements HttpCacheExceptionInterface
+class InvalidTagException extends \InvalidArgumentException implements HttpCacheException
 {
 }

--- a/src/Exception/InvalidUrlException.php
+++ b/src/Exception/InvalidUrlException.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCache\Exception;
 /**
  * Thrown during setup if the configuration for a proxy client is invalid.
  */
-class InvalidUrlException extends InvalidArgumentException implements HttpCacheExceptionInterface
+class InvalidUrlException extends InvalidArgumentException implements HttpCacheException
 {
     /**
      * @param string $url    The invalid URL

--- a/src/Exception/MissingHostException.php
+++ b/src/Exception/MissingHostException.php
@@ -15,7 +15,7 @@ namespace FOS\HttpCache\Exception;
  * Thrown when there is no default host configured and an invalidation request
  * with just a path is made.
  */
-class MissingHostException extends \RuntimeException implements HttpCacheExceptionInterface
+class MissingHostException extends \RuntimeException implements HttpCacheException
 {
     /**
      * @param string $path The path that was asked to be invalidated

--- a/src/Exception/ProxyResponseException.php
+++ b/src/Exception/ProxyResponseException.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Wrapping an error response from the caching proxy.
  */
-class ProxyResponseException extends \RuntimeException implements HttpCacheExceptionInterface
+class ProxyResponseException extends \RuntimeException implements HttpCacheException
 {
     /**
      * @param ResponseInterface $response HTTP response

--- a/src/Exception/ProxyUnreachableException.php
+++ b/src/Exception/ProxyUnreachableException.php
@@ -17,7 +17,7 @@ use Http\Client\Exception\RequestException;
  * Thrown when a request to the reverse caching proxy fails to establish a
  * connection.
  */
-class ProxyUnreachableException extends \RuntimeException implements HttpCacheExceptionInterface
+class ProxyUnreachableException extends \RuntimeException implements HttpCacheException
 {
     /**
      * @param RequestException $requestException

--- a/src/Exception/UnsupportedProxyOperationException.php
+++ b/src/Exception/UnsupportedProxyOperationException.php
@@ -15,7 +15,7 @@ namespace FOS\HttpCache\Exception;
  * Thrown when the CacheInvalidator is asked for an operation the underlying
  * cache proxy does not support.
  */
-class UnsupportedProxyOperationException extends \RuntimeException implements HttpCacheExceptionInterface
+class UnsupportedProxyOperationException extends \RuntimeException implements HttpCacheException
 {
     /**
      * @param string $method Name of the HTTP method that would be required

--- a/src/ProxyClient/HttpProxyClient.php
+++ b/src/ProxyClient/HttpProxyClient.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author David de Boer <david@driebit.nl>
  */
-abstract class HttpProxyClient implements ProxyClientInterface
+abstract class HttpProxyClient implements ProxyClient
 {
     /**
      * Dispatcher for invalidation HTTP requests.

--- a/src/ProxyClient/Invalidation/BanCapable.php
+++ b/src/ProxyClient/Invalidation/BanCapable.php
@@ -11,13 +11,13 @@
 
 namespace FOS\HttpCache\ProxyClient\Invalidation;
 
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
  * An HTTP cache that supports invalidation by banning, that is, removing
  * objects from the cache that match a regular expression.
  */
-interface BanInterface extends ProxyClientInterface
+interface BanCapable extends ProxyClient
 {
     const REGEX_MATCH_ALL = '.*';
     const CONTENT_TYPE_ALL = self::REGEX_MATCH_ALL;

--- a/src/ProxyClient/Invalidation/PurgeCapable.php
+++ b/src/ProxyClient/Invalidation/PurgeCapable.php
@@ -11,12 +11,12 @@
 
 namespace FOS\HttpCache\ProxyClient\Invalidation;
 
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
  * An HTTP cache that supports invalidation by purging: Remove one URL from the cache.
  */
-interface PurgeInterface extends ProxyClientInterface
+interface PurgeCapable extends ProxyClient
 {
     /**
      * Purge a URL.

--- a/src/ProxyClient/Invalidation/RefreshCapable.php
+++ b/src/ProxyClient/Invalidation/RefreshCapable.php
@@ -11,13 +11,13 @@
 
 namespace FOS\HttpCache\ProxyClient\Invalidation;
 
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
  * An HTTP cache that supports invalidation by refresh requests that force a
  * cache miss for one specific URL.
  */
-interface RefreshInterface extends ProxyClientInterface
+interface RefreshCapable extends ProxyClient
 {
     /**
      * Refresh a URL.

--- a/src/ProxyClient/Invalidation/TagCapable.php
+++ b/src/ProxyClient/Invalidation/TagCapable.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\ProxyClient\Invalidation;
 
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
  * An HTTP cache that supports invalidation by a cache tag, that is, removing
@@ -20,7 +20,7 @@ use FOS\HttpCache\ProxyClient\ProxyClientInterface;
  * HTTP responses must carry the tags header name with the tags header value
  * for tag invalidation to work.
  */
-interface TagsInterface extends ProxyClientInterface
+interface TagCapable extends ProxyClient
 {
     /**
      * Remove/Expire cache objects based on cache tags.

--- a/src/ProxyClient/MultiplexerClient.php
+++ b/src/ProxyClient/MultiplexerClient.php
@@ -13,31 +13,31 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\Exception\ExceptionCollection;
 use FOS\HttpCache\Exception\InvalidArgumentException;
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 
 /**
  * This class forwards invalidation to all attached clients.
  *
  * @author Emanuele Panzeri <thepanz@gmail.com>
  */
-class MultiplexerClient implements BanInterface, PurgeInterface, RefreshInterface
+class MultiplexerClient implements BanCapable, PurgeCapable, RefreshCapable
 {
     /**
-     * @var ProxyClientInterface[]
+     * @var ProxyClient[]
      */
     private $proxyClients;
 
     /**
      * MultiplexerClient constructor.
      *
-     * @param ProxyClientInterface[] $proxyClients The list of Proxy clients
+     * @param ProxyClient[] $proxyClients The list of Proxy clients
      */
     public function __construct(array $proxyClients)
     {
         foreach ($proxyClients as $proxyClient) {
-            if (!$proxyClient instanceof ProxyClientInterface) {
+            if (!$proxyClient instanceof ProxyClient) {
                 throw new InvalidArgumentException('Expected ProxyClientInterface, got: '.
                     (is_object($proxyClient) ? get_class($proxyClient) : gettype($proxyClient))
                 );
@@ -56,7 +56,7 @@ class MultiplexerClient implements BanInterface, PurgeInterface, RefreshInterfac
      */
     public function ban(array $headers)
     {
-        $this->invoke(BanInterface::class, 'ban', [$headers]);
+        $this->invoke(BanCapable::class, 'ban', [$headers]);
 
         return $this;
     }
@@ -73,7 +73,7 @@ class MultiplexerClient implements BanInterface, PurgeInterface, RefreshInterfac
      */
     public function banPath($path, $contentType = null, $hosts = null)
     {
-        $this->invoke(BanInterface::class, 'banPath', [$path, $contentType, $hosts]);
+        $this->invoke(BanCapable::class, 'banPath', [$path, $contentType, $hosts]);
 
         return $this;
     }
@@ -105,7 +105,7 @@ class MultiplexerClient implements BanInterface, PurgeInterface, RefreshInterfac
      */
     public function purge($url, array $headers = array())
     {
-        $this->invoke(PurgeInterface::class, 'purge', [$url, $headers]);
+        $this->invoke(PurgeCapable::class, 'purge', [$url, $headers]);
 
         return $this;
     }
@@ -120,7 +120,7 @@ class MultiplexerClient implements BanInterface, PurgeInterface, RefreshInterfac
      */
     public function refresh($url, array $headers = [])
     {
-        $this->invoke(RefreshInterface::class, 'refresh', [$url, $headers]);
+        $this->invoke(RefreshCapable::class, 'refresh', [$url, $headers]);
 
         return $this;
     }

--- a/src/ProxyClient/Nginx.php
+++ b/src/ProxyClient/Nginx.php
@@ -11,8 +11,8 @@
 
 namespace FOS\HttpCache\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 
 /**
  * NGINX HTTP cache invalidator.
@@ -23,7 +23,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
  *
  * @author Simone Fumagalli <simone@iliveinperego.com>
  */
-class Nginx extends HttpProxyClient implements PurgeInterface, RefreshInterface
+class Nginx extends HttpProxyClient implements PurgeCapable, RefreshCapable
 {
     const HTTP_METHOD_PURGE = 'PURGE';
     const HTTP_METHOD_REFRESH = 'GET';

--- a/src/ProxyClient/Noop.php
+++ b/src/ProxyClient/Noop.php
@@ -11,10 +11,10 @@
 
 namespace FOS\HttpCache\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 
 /**
  * This is a no operation client, its only purpose is to provide an implementation for use in an enviroments that
@@ -22,7 +22,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
  *
  * @author Gavin Staniforth <gavin@gsdev.me>
  */
-class Noop implements ProxyClientInterface, BanInterface, PurgeInterface, RefreshInterface, TagsInterface
+class Noop implements ProxyClient, BanCapable, PurgeCapable, RefreshCapable, TagCapable
 {
     /**
      * {@inheritdoc}

--- a/src/ProxyClient/ProxyClient.php
+++ b/src/ProxyClient/ProxyClient.php
@@ -18,7 +18,7 @@ use FOS\HttpCache\Exception\ExceptionCollection;
  *
  * Implementations should implement at least one of the Invalidation interfaces.
  */
-interface ProxyClientInterface
+interface ProxyClient
 {
     /**
      * Send all pending invalidation requests.

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -11,8 +11,8 @@
 
 namespace FOS\HttpCache\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 
 /**
@@ -24,7 +24,7 @@ use FOS\HttpCache\SymfonyCache\PurgeListener;
  * @author David de Boer <david@driebit.nl>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class Symfony extends HttpProxyClient implements PurgeInterface, RefreshInterface
+class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
 {
     const HTTP_METHOD_REFRESH = 'GET';
 

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -12,10 +12,10 @@
 namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\Exception\InvalidArgumentException;
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 
 /**
  * Varnish HTTP cache invalidator.
@@ -28,7 +28,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
  *
  * @author David de Boer <david@driebit.nl>
  */
-class Varnish extends HttpProxyClient implements BanInterface, PurgeInterface, RefreshInterface, TagsInterface
+class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, RefreshCapable, TagCapable
 {
     const HTTP_METHOD_BAN = 'BAN';
     const HTTP_METHOD_PURGE = 'PURGE';

--- a/src/ResponseTagger.php
+++ b/src/ResponseTagger.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache;
 
 use FOS\HttpCache\Exception\InvalidTagException;
-use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -32,7 +32,7 @@ class ResponseTagger
     private $options;
 
     /**
-     * @var TagsInterface
+     * @var TagCapable
      */
     private $proxyClient;
 
@@ -48,10 +48,10 @@ class ResponseTagger
      *
      * - strict (bool) Default: false. If set to true, throws exception when adding empty tags
      *
-     * @param TagsInterface $proxyClient
-     * @param array         $options
+     * @param TagCapable $proxyClient
+     * @param array      $options
      */
-    public function __construct(TagsInterface $proxyClient, array $options = array())
+    public function __construct(TagCapable $proxyClient, array $options = array())
     {
         $this->proxyClient = $proxyClient;
 

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 class CacheEvent extends Event
 {
     /**
-     * @var CacheInvalidationInterface
+     * @var CacheInvalidation
      */
     private $kernel;
 
@@ -41,11 +41,11 @@ class CacheEvent extends Event
     /**
      * Make sure your $kernel implements CacheInvalidationInterface.
      *
-     * @param CacheInvalidationInterface $kernel   The kernel raising with this event
-     * @param Request                    $request  The request being processed
-     * @param Response                   $response The response, if available
+     * @param CacheInvalidation $kernel   The kernel raising with this event
+     * @param Request           $request  The request being processed
+     * @param Response          $response The response, if available
      */
-    public function __construct(CacheInvalidationInterface $kernel, Request $request, Response $response = null)
+    public function __construct(CacheInvalidation $kernel, Request $request, Response $response = null)
     {
         $this->kernel = $kernel;
         $this->request = $request;
@@ -55,7 +55,7 @@ class CacheEvent extends Event
     /**
      * Get the cache kernel that raised this event.
      *
-     * @return CacheInvalidationInterface
+     * @return CacheInvalidation
      */
     public function getKernel()
     {

--- a/src/SymfonyCache/CacheInvalidation.php
+++ b/src/SymfonyCache/CacheInvalidation.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 /**
  * Interface for a HttpCache that supports active cache invalidation.
  */
-interface CacheInvalidationInterface extends HttpKernelInterface
+interface CacheInvalidation extends HttpKernelInterface
 {
     /**
      * Forwards the Request to the backend and determines whether the response should be stored.

--- a/src/Test/EventDispatchingHttpCacheTestCase.php
+++ b/src/Test/EventDispatchingHttpCacheTestCase.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Test;
 
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\Events;
@@ -39,7 +39,7 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
      *
      * @param array $mockedMethods List of methods to mock
      *
-     * @return CacheInvalidationInterface|EventDispatchingHttpCache|\PHPUnit_Framework_MockObject_MockObject
+     * @return CacheInvalidation|EventDispatchingHttpCache|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function getHttpCachePartialMock(array $mockedMethods = null)
     {
@@ -50,7 +50,7 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
             ->getMock()
         ;
 
-        $this->assertInstanceOf(CacheInvalidationInterface::class, $mock);
+        $this->assertInstanceOf(CacheInvalidation::class, $mock);
 
         // Force setting options property since we can't use original constructor.
         $options = [
@@ -79,11 +79,11 @@ abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_Test
     /**
      * Set the store property on a HttpCache to a StoreInterface expecting one write with request and response.
      *
-     * @param CacheInvalidationInterface $httpCache
-     * @param Request                    $request
-     * @param Response                   $response
+     * @param CacheInvalidation $httpCache
+     * @param Request           $request
+     * @param Response          $response
      */
-    protected function setStoreMock(CacheInvalidationInterface $httpCache, Request $request, Response $response)
+    protected function setStoreMock(CacheInvalidation $httpCache, Request $request, Response $response)
     {
         $store = $this->getMock(StoreInterface::class);
         $store
@@ -367,7 +367,7 @@ class TestListener implements EventSubscriberInterface
     private $test;
 
     /**
-     * @var CacheInvalidationInterface The kernel to ensure the event carries the correct kernel
+     * @var CacheInvalidation The kernel to ensure the event carries the correct kernel
      */
     private $kernel;
 
@@ -378,7 +378,7 @@ class TestListener implements EventSubscriberInterface
 
     public function __construct(
         EventDispatchingHttpCacheTestCase $test,
-        CacheInvalidationInterface $kernel,
+        CacheInvalidation $kernel,
         Request $request
     ) {
         $this->test = $test;
@@ -447,7 +447,7 @@ class SimpleListener
     private $test;
 
     /**
-     * @var CacheInvalidationInterface The kernel to ensure the event carries the correct kernel
+     * @var CacheInvalidation The kernel to ensure the event carries the correct kernel
      */
     private $kernel;
 
@@ -458,7 +458,7 @@ class SimpleListener
 
     public function __construct(
         EventDispatchingHttpCacheTestCase $test,
-        CacheInvalidationInterface $kernel,
+        CacheInvalidation $kernel,
         Request $request
     ) {
         $this->test = $test;

--- a/src/UserContext/ContextProvider.php
+++ b/src/UserContext/ContextProvider.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCache\UserContext;
 /**
  * Allow a class to update a user context.
  */
-interface ContextProviderInterface
+interface ContextProvider
 {
     /**
      * This function is called before generating the hash of a UserContext.

--- a/src/UserContext/HashGenerator.php
+++ b/src/UserContext/HashGenerator.php
@@ -19,14 +19,14 @@ use FOS\HttpCache\Exception\InvalidArgumentException;
 class HashGenerator
 {
     /**
-     * @var ContextProviderInterface[]
+     * @var ContextProvider[]
      */
     private $providers = [];
 
     /**
      * Constructor.
      *
-     * @param ContextProviderInterface[] $providers
+     * @param ContextProvider[] $providers
      *
      * @throws InvalidArgumentException If no providers are supplied
      */
@@ -65,9 +65,9 @@ class HashGenerator
     /**
      * Register a provider to be called for updating a UserContext before generating the Hash.
      *
-     * @param ContextProviderInterface $provider A context provider to be called to get context information about the current request
+     * @param ContextProvider $provider A context provider to be called to get context information about the current request
      */
-    private function registerProvider(ContextProviderInterface $provider)
+    private function registerProvider(ContextProvider $provider)
     {
         $this->providers[] = $provider;
     }

--- a/tests/Functional/Fixtures/Symfony/AppCache.php
+++ b/tests/Functional/Fixtures/Symfony/AppCache.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Functional\Fixtures\Symfony;
 
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpCache\SurrogateInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class AppCache extends HttpCache implements CacheInvalidationInterface
+class AppCache extends HttpCache implements CacheInvalidation
 {
     use EventDispatchingHttpCache;
 

--- a/tests/Functional/ProxyClient/BanAssertions.php
+++ b/tests/Functional/ProxyClient/BanAssertions.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Functional\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 
 /**
  * Assertions that do the ban operations.
@@ -21,11 +21,11 @@ trait BanAssertions
     /**
      * Asserting that banning everything leads to all content getting invalidated.
      *
-     * @param BanInterface $proxyClient The client to send ban instructions to the cache
-     * @param string       $header      The header that holds the URLs
-     * @param array        $paths       The paths to get, defaults to [/cache.php, json.php]
+     * @param BanCapable $proxyClient The client to send ban instructions to the cache
+     * @param string     $header      The header that holds the URLs
+     * @param array      $paths       The paths to get, defaults to [/cache.php, json.php]
      */
-    protected function assertBanAll(BanInterface $proxyClient, $header, array $paths = ['/cache.php', '/json.php'])
+    protected function assertBanAll(BanCapable $proxyClient, $header, array $paths = ['/cache.php', '/json.php'])
     {
         foreach ($paths as $path) {
             $this->assertMiss($this->getResponse($path));
@@ -42,12 +42,12 @@ trait BanAssertions
     /**
      * Asserting that only banning the right host leads to content getting invalidated.
      *
-     * @param BanInterface $proxyClient The client to send ban instructions to the cache
-     * @param string       $header      The header that holds the URLs
-     * @param string       $hostname    Name of the host so we can invalidate that host
-     * @param string       $path        The path to get, defaults to[/cache.php
+     * @param BanCapable $proxyClient The client to send ban instructions to the cache
+     * @param string     $header      The header that holds the URLs
+     * @param string     $hostname    Name of the host so we can invalidate that host
+     * @param string     $path        The path to get, defaults to /cache.php
      */
-    protected function assertBanHost(BanInterface $proxyClient, $header, $hostname, $path = '/cache.php')
+    protected function assertBanHost(BanCapable $proxyClient, $header, $hostname, $path = '/cache.php')
     {
         $this->assertMiss($this->getResponse($path));
         $this->assertHit($this->getResponse($path));
@@ -62,10 +62,10 @@ trait BanAssertions
     /**
      * Asserting that banPath leads to content getting invalidated.
      *
-     * @param BanInterface $proxyClient The client to send ban instructions to the cache
-     * @param array        $paths       The paths to get, defaults to [/cache.php, json.php]
+     * @param BanCapable $proxyClient The client to send ban instructions to the cache
+     * @param array      $paths       The paths to get, defaults to [/cache.php, json.php]
      */
-    protected function assertBanPath(BanInterface $proxyClient, array $paths = ['/cache.php', '/json.php'])
+    protected function assertBanPath(BanCapable $proxyClient, array $paths = ['/cache.php', '/json.php'])
     {
         foreach ($paths as $path) {
             $this->assertMiss($this->getResponse($path));
@@ -82,11 +82,11 @@ trait BanAssertions
     /**
      * Asserting that banPath leads to content getting invalidated.
      *
-     * @param BanInterface $proxyClient The client to send ban instructions to the cache
-     * @param string       $htmlPath    Path to a HTML content, defaults to /cache.php
-     * @param string       $otherPath   Path to a non-HTML content, defaults to json.php
+     * @param BanCapable $proxyClient The client to send ban instructions to the cache
+     * @param string     $htmlPath    Path to a HTML content, defaults to /cache.php
+     * @param string     $otherPath   Path to a non-HTML content, defaults to json.php
      */
-    protected function assertBanPathContentType(BanInterface $proxyClient, $htmlPath = '/cache.php', $otherPath = '/json.php')
+    protected function assertBanPathContentType(BanCapable $proxyClient, $htmlPath = '/cache.php', $otherPath = '/json.php')
     {
         $this->assertMiss($this->getResponse($htmlPath));
         $this->assertHit($this->getResponse($htmlPath));

--- a/tests/Functional/ProxyClient/PurgeAssertions.php
+++ b/tests/Functional/ProxyClient/PurgeAssertions.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Functional\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 
 /**
  * Assertions that do the purge operations.
@@ -21,10 +21,10 @@ trait PurgeAssertions
     /**
      * Asserting that purging leads to invalidated content.
      *
-     * @param PurgeInterface $proxyClient The client to send purge instructions to the cache
-     * @param string         $path        The path to get and purge, defaults to /cache.php
+     * @param PurgeCapable $proxyClient The client to send purge instructions to the cache
+     * @param string       $path        The path to get and purge, defaults to /cache.php
      */
-    protected function assertPurge(PurgeInterface $proxyClient, $path = '/cache.php')
+    protected function assertPurge(PurgeCapable $proxyClient, $path = '/cache.php')
     {
         $this->assertMiss($this->getResponse($path));
         $this->assertHit($this->getResponse($path));
@@ -36,11 +36,11 @@ trait PurgeAssertions
     /**
      * Asserting that purging including the domain leads to invalidated content.
      *
-     * @param PurgeInterface $proxyClient The client to send purge instructions to the cache
-     * @param string         $host        The host name to use in the purge request
-     * @param string         $path        The path to get and purge, defaults to /cache.php
+     * @param PurgeCapable $proxyClient The client to send purge instructions to the cache
+     * @param string       $host        The host name to use in the purge request
+     * @param string       $path        The path to get and purge, defaults to /cache.php
      */
-    protected function assertPurgeHost(PurgeInterface $proxyClient, $host, $path = '/cache.php')
+    protected function assertPurgeHost(PurgeCapable $proxyClient, $host, $path = '/cache.php')
     {
         $this->assertMiss($this->getResponse($path));
         $this->assertHit($this->getResponse($path));
@@ -49,7 +49,7 @@ trait PurgeAssertions
         $this->assertMiss($this->getResponse($path));
     }
 
-    protected function assertPurgeContentType(PurgeInterface $proxyClient, $path = '/negotiation.php')
+    protected function assertPurgeContentType(PurgeCapable $proxyClient, $path = '/negotiation.php')
     {
         $json = ['Accept' => 'application/json'];
         $html = ['Accept' => 'text/html'];

--- a/tests/Functional/ProxyClient/RefreshAssertions.php
+++ b/tests/Functional/ProxyClient/RefreshAssertions.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Functional\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 
 /**
  * Assertions that do the refresh operations.
@@ -21,10 +21,10 @@ trait RefreshAssertions
     /**
      * Asserting that refreshing leads to updated content that is already cached.
      *
-     * @param RefreshInterface $proxyClient The client to send refresh instructions to the cache
-     * @param string           $path        The path to get and refresh, defaults to /cache.php
+     * @param RefreshCapable $proxyClient The client to send refresh instructions to the cache
+     * @param string         $path        The path to get and refresh, defaults to /cache.php
      */
-    protected function assertRefresh(RefreshInterface $proxyClient, $path = '/cache.php')
+    protected function assertRefresh(RefreshCapable $proxyClient, $path = '/cache.php')
     {
         $this->assertMiss($this->getResponse($path));
         $response = $this->getResponse($path);
@@ -46,10 +46,10 @@ trait RefreshAssertions
     /**
      * Asserting that refreshing one variant does not touch the other variants.
      *
-     * @param RefreshInterface $proxyClient The client to send refresh instructions to the cache
-     * @param string           $path        The path to get and refresh, defaults to /negotiation.php
+     * @param RefreshCapable $proxyClient The client to send refresh instructions to the cache
+     * @param string         $path        The path to get and refresh, defaults to /negotiation.php
      */
-    protected function assertRefreshContentType(RefreshInterface $proxyClient, $path = '/negotiation.php')
+    protected function assertRefreshContentType(RefreshCapable $proxyClient, $path = '/negotiation.php')
     {
         $json = ['Accept' => 'application/json'];
         $html = ['Accept' => 'text/html'];

--- a/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
+++ b/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Functional\Varnish;
 
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use FOS\HttpCache\SymfonyCache\DebugListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
@@ -62,7 +62,7 @@ class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class AppCache extends HttpCache implements CacheInvalidationInterface
+class AppCache extends HttpCache implements CacheInvalidation
 {
     use EventDispatchingHttpCache;
 

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -17,11 +17,11 @@ use FOS\HttpCache\Exception\ExceptionCollection;
 use FOS\HttpCache\Exception\ProxyResponseException;
 use FOS\HttpCache\Exception\ProxyUnreachableException;
 use FOS\HttpCache\Exception\UnsupportedProxyOperationException;
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\ProxyClient\Varnish;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\RequestException;
@@ -49,8 +49,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportsFalse()
     {
-        /** @var MockInterface|ProxyClientInterface $proxyClient */
-        $proxyClient = \Mockery::mock(ProxyClientInterface::class);
+        /** @var MockInterface|ProxyClient $proxyClient */
+        $proxyClient = \Mockery::mock(ProxyClient::class);
 
         $cacheInvalidator = new CacheInvalidator($proxyClient);
 
@@ -65,8 +65,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testSupportsInvalid()
     {
-        /** @var MockInterface|ProxyClientInterface $proxyClient */
-        $proxyClient = \Mockery::mock(ProxyClientInterface::class);
+        /** @var MockInterface|ProxyClient $proxyClient */
+        $proxyClient = \Mockery::mock(ProxyClient::class);
 
         $cacheInvalidator = new CacheInvalidator($proxyClient);
 
@@ -75,8 +75,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidatePath()
     {
-        /** @var MockInterface|PurgeInterface $purge */
-        $purge = \Mockery::mock(PurgeInterface::class)
+        /** @var MockInterface|PurgeCapable $purge */
+        $purge = \Mockery::mock(PurgeCapable::class)
             ->shouldReceive('purge')->once()->with('/my/route', [])
             ->shouldReceive('purge')->once()->with('/my/route', ['X-Test-Header' => 'xyz'])
             ->shouldReceive('flush')->once()
@@ -94,8 +94,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
     public function testRefreshPath()
     {
         $headers = ['X' => 'Y'];
-        /** @var MockInterface|RefreshInterface $refresh */
-        $refresh = \Mockery::mock(RefreshInterface::class)
+        /** @var MockInterface|RefreshCapable $refresh */
+        $refresh = \Mockery::mock(RefreshCapable::class)
             ->shouldReceive('refresh')->once()->with('/my/route', $headers)
             ->shouldReceive('flush')->never()
             ->getMock();
@@ -114,8 +114,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
             'Other-Header' => '^a|b|c$',
         ];
 
-        /** @var MockInterface|BanInterface $ban */
-        $ban = \Mockery::mock(BanInterface::class)
+        /** @var MockInterface|BanCapable $ban */
+        $ban = \Mockery::mock(BanCapable::class)
             ->shouldReceive('ban')
             ->with($headers)
             ->once()
@@ -132,8 +132,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
             'post-type-2',
         ];
 
-        /** @var MockInterface|TagsInterface $tagHandler */
-        $tagHandler = \Mockery::mock(TagsInterface::class)
+        /** @var MockInterface|TagCapable $tagHandler */
+        $tagHandler = \Mockery::mock(TagCapable::class)
             ->shouldReceive('invalidateTags')
             ->with($tags)
             ->once()
@@ -145,8 +145,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidateRegex()
     {
-        /** @var MockInterface|BanInterface $ban */
-        $ban = \Mockery::mock(BanInterface::class)
+        /** @var MockInterface|BanCapable $ban */
+        $ban = \Mockery::mock(BanCapable::class)
             ->shouldReceive('banPath')
             ->with('/a', 'b', ['example.com'])
             ->once()
@@ -158,8 +158,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testMethodException()
     {
-        /** @var MockInterface|ProxyClientInterface $proxyClient */
-        $proxyClient = \Mockery::mock(ProxyClientInterface::class);
+        /** @var MockInterface|ProxyClient $proxyClient */
+        $proxyClient = \Mockery::mock(ProxyClient::class);
         $cacheInvalidator = new CacheInvalidator($proxyClient);
         try {
             $cacheInvalidator->invalidatePath('/');
@@ -215,8 +215,8 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
         $exceptions = new ExceptionCollection();
         $exceptions->add($unreachableException)->add($responseException);
 
-        /** @var MockInterface|ProxyClientInterface $proxyClient */
-        $proxyClient = \Mockery::mock(ProxyClientInterface::class)
+        /** @var MockInterface|ProxyClient $proxyClient */
+        $proxyClient = \Mockery::mock(ProxyClient::class)
             ->shouldReceive('flush')->once()->andThrow($exceptions)
             ->getMock();
 

--- a/tests/Unit/ProxyClient/MultiplexerClientTest.php
+++ b/tests/Unit/ProxyClient/MultiplexerClientTest.php
@@ -11,11 +11,11 @@
 
 namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 
-use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\MultiplexerClient;
-use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use FOS\HttpCache\ProxyClient\ProxyClient;
 
 class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,13 +23,13 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
     {
         $headers = ['Header1' => 'Header1-Value'];
 
-        $mockClient1 = \Mockery::mock(BanInterface::class)
+        $mockClient1 = \Mockery::mock(BanCapable::class)
             ->shouldReceive('ban')
             ->once()
             ->with($headers)
             ->getMock();
 
-        $mockClient2 = \Mockery::mock(BanInterface::class)
+        $mockClient2 = \Mockery::mock(BanCapable::class)
             ->shouldReceive('ban')
             ->once()
             ->with($headers)
@@ -46,12 +46,12 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
         $contentType = 'text/css';
         $hosts = 'example.com';
 
-        $mockClient1 = \Mockery::mock(BanInterface::class)
+        $mockClient1 = \Mockery::mock(BanCapable::class)
             ->shouldReceive('banPath')
             ->once()
             ->with($path, $contentType, $hosts)
             ->getMock();
-        $mockClient2 = \Mockery::mock(BanInterface::class)
+        $mockClient2 = \Mockery::mock(BanCapable::class)
             ->shouldReceive('banPath')
             ->once()
             ->with($path, $contentType, $hosts)
@@ -64,12 +64,12 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
 
     public function testFlush()
     {
-        $mockClient1 = \Mockery::mock(ProxyClientInterface::class)
+        $mockClient1 = \Mockery::mock(ProxyClient::class)
             ->shouldReceive('flush')
             ->once()
             ->andReturn(4)
             ->getMock();
-        $mockClient2 = \Mockery::mock(ProxyClientInterface::class)
+        $mockClient2 = \Mockery::mock(ProxyClient::class)
             ->shouldReceive('flush')
             ->once()
             ->andReturn(6)
@@ -85,17 +85,17 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
         $url = 'example.com';
         $headers = ['Header1' => 'Header1-Value'];
 
-        $mockClient1 = \Mockery::mock(RefreshInterface::class)
+        $mockClient1 = \Mockery::mock(RefreshCapable::class)
             ->shouldReceive('refresh')
             ->once()
             ->with($url, $headers)
             ->getMock();
-        $mockClient2 = \Mockery::mock(RefreshInterface::class)
+        $mockClient2 = \Mockery::mock(RefreshCapable::class)
             ->shouldReceive('refresh')
             ->once()
             ->with($url, $headers)
             ->getMock();
-        $mockClient3 = \Mockery::mock(ProxyClientInterface::class);
+        $mockClient3 = \Mockery::mock(ProxyClient::class);
 
         $multiplexer = new MultiplexerClient([$mockClient1, $mockClient2, $mockClient3]);
 
@@ -107,16 +107,16 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
         $url = 'example.com';
         $headers = ['Header1' => 'Header1-Value'];
 
-        $mockClient1 = \Mockery::mock(PurgeInterface::class)
+        $mockClient1 = \Mockery::mock(PurgeCapable::class)
             ->shouldReceive('purge')
             ->once()
             ->with($url, $headers)
             ->getMock();
-        $mockClient2 = \Mockery::mock(PurgeInterface::class)
+        $mockClient2 = \Mockery::mock(PurgeCapable::class)
             ->shouldReceive('purge')
             ->with($url, $headers)
             ->getMock();
-        $mockClient3 = \Mockery::mock(ProxyClientInterface::class);
+        $mockClient3 = \Mockery::mock(ProxyClient::class);
 
         $multiplexer = new MultiplexerClient([$mockClient1, $mockClient2, $mockClient3]);
 
@@ -132,7 +132,7 @@ class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param ProxyClientInterface[] $clients
+     * @param ProxyClient[] $clients
      *
      * @dataProvider provideInvalidClient
      * @expectedException \FOS\HttpCache\Exception\InvalidArgumentException

--- a/tests/Unit/ResponseTaggerTest.php
+++ b/tests/Unit/ResponseTaggerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit;
 
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
-use FOS\HttpCache\ProxyClient\Invalidation\TagsInterface;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\ResponseTagger;
 use FOS\HttpCache\ProxyClient\Varnish;
 use FOS\HttpCache\Exception\InvalidTagException;
@@ -22,7 +22,7 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetTagsHeaderValue()
     {
-        $proxyClient = \Mockery::mock(TagsInterface::class)
+        $proxyClient = \Mockery::mock(TagCapable::class)
             ->shouldReceive('getTagsHeaderValue')
             ->with(['post-1', 'test,post'])
             ->once()
@@ -38,7 +38,7 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
 
     public function testTagResponseReplace()
     {
-        $proxyClient = \Mockery::mock(TagsInterface::class)
+        $proxyClient = \Mockery::mock(TagCapable::class)
             ->shouldReceive('getTagsHeaderValue')
             ->with(['tag-1', 'tag-2'])
             ->once()
@@ -61,7 +61,7 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
 
     public function testTagResponseAdd()
     {
-        $proxyClient = \Mockery::mock(TagsInterface::class)
+        $proxyClient = \Mockery::mock(TagCapable::class)
             ->shouldReceive('getTagsHeaderValue')
             ->with(['tag-1', 'tag-2'])
             ->once()
@@ -85,7 +85,7 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
     public function testTagResponseNoTags()
     {
         /** @var TagsInterface $proxyClient */
-        $proxyClient = \Mockery::mock(TagsInterface::class)
+        $proxyClient = \Mockery::mock(TagCapable::class)
             ->shouldReceive('getTagsHeaderValue')->never()
             ->getMock();
 
@@ -116,7 +116,7 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
 
     public function testNonStrictEmptyTag()
     {
-        $proxyClient = \Mockery::mock(TagsInterface::class)
+        $proxyClient = \Mockery::mock(TagCapable::class)
             ->shouldReceive('getTagsHeaderValue')
             ->with(['post-1'])
             ->once()

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use Mockery\MockInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,13 +21,13 @@ use Symfony\Component\HttpFoundation\Response;
 class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CacheInvalidationInterface|MockInterface
+     * @var CacheInvalidation|MockInterface
      */
     private $kernel;
 
     public function setUp()
     {
-        $this->kernel = \Mockery::mock(CacheInvalidationInterface::class);
+        $this->kernel = \Mockery::mock(CacheInvalidation::class);
     }
 
     public function testCustomTtl()

--- a/tests/Unit/SymfonyCache/DebugListenerTest.php
+++ b/tests/Unit/SymfonyCache/DebugListenerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\DebugListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,13 +20,13 @@ use Symfony\Component\HttpFoundation\Response;
 class DebugListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CacheInvalidationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject
      */
     private $kernel;
 
     public function setUp()
     {
-        $this->kernel = \Mockery::mock(CacheInvalidationInterface::class);
+        $this->kernel = \Mockery::mock(CacheInvalidation::class);
     }
 
     public function testDebugHit()

--- a/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
+++ b/tests/Unit/SymfonyCache/EventDispatchingHttpCacheTest.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\Test\EventDispatchingHttpCacheTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +28,7 @@ class EventDispatchingHttpCacheTest extends EventDispatchingHttpCacheTestCase
     }
 }
 
-class AppCache extends HttpCache implements CacheInvalidationInterface
+class AppCache extends HttpCache implements CacheInvalidation
 {
     use EventDispatchingHttpCache;
 

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use Mockery\MockInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -142,11 +142,11 @@ class PurgeListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return CacheInvalidationInterface|MockInterface
+     * @return CacheInvalidation|MockInterface
      */
     private function getKernelMock(StoreInterface $store)
     {
-        return \Mockery::mock(CacheInvalidationInterface::class)
+        return \Mockery::mock(CacheInvalidation::class)
             ->shouldReceive('getStore')
             ->once()
             ->andReturn($store)
@@ -154,11 +154,11 @@ class PurgeListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return CacheInvalidationInterface|MockInterface
+     * @return CacheInvalidation|MockInterface
      */
     private function getUnusedKernelMock()
     {
-        return \Mockery::mock(CacheInvalidationInterface::class)
+        return \Mockery::mock(CacheInvalidation::class)
             ->shouldNotReceive('getStore')
             ->getMock();
     }

--- a/tests/Unit/SymfonyCache/RefreshListenerTest.php
+++ b/tests/Unit/SymfonyCache/RefreshListenerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\RefreshListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
@@ -21,13 +21,13 @@ use Symfony\Component\HttpFoundation\Response;
 class RefreshListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CacheInvalidationInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject
      */
     private $kernel;
 
     public function setUp()
     {
-        $this->kernel = $this->getMock(CacheInvalidationInterface::class);
+        $this->kernel = $this->getMock(CacheInvalidation::class);
     }
 
     public function testRefreshAllowed()

--- a/tests/Unit/SymfonyCache/UserContextListenerTest.php
+++ b/tests/Unit/SymfonyCache/UserContextListenerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
-use FOS\HttpCache\SymfonyCache\CacheInvalidationInterface;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Mockery\MockInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,13 +21,13 @@ use Symfony\Component\HttpFoundation\Response;
 class UserContextListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var CacheInvalidationInterface|MockInterface
+     * @var CacheInvalidation|MockInterface
      */
     private $kernel;
 
     public function setUp()
     {
-        $this->kernel = \Mockery::mock(CacheInvalidationInterface::class);
+        $this->kernel = \Mockery::mock(CacheInvalidation::class);
     }
 
     /**

--- a/tests/Unit/UserContext/HashGeneratorTest.php
+++ b/tests/Unit/UserContext/HashGeneratorTest.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Tests\Unit\UserContext;
 
-use FOS\HttpCache\UserContext\ContextProviderInterface;
+use FOS\HttpCache\UserContext\ContextProvider;
 use FOS\HttpCache\UserContext\HashGenerator;
 use FOS\HttpCache\UserContext\UserContext;
 
@@ -35,7 +35,7 @@ class HashGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class FooProvider implements ContextProviderInterface
+class FooProvider implements ContextProvider
 {
     public function updateUserContext(UserContext $context)
     {


### PR DESCRIPTION
Following a convention of many PHP libraries, including PHP-HTTP.
See also https://github.com/php-http/HttplugBundle/issues/28