### PR TITLE
Added interface for the hash generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).q
+See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
 2.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
+See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).q
 
 2.0.0
 -----
@@ -10,6 +10,8 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 * Raised minimum PHP version to 5.5.
 * **BC break:** Removed the `Interface` suffix from all interfaces.
+* **BC break:** Renamed ``HashGenerator`` to ``DefaultHashGenerator``.
+* Added interface ``HashGenerator``
 
 ### HTTP
 

--- a/doc/user-context.rst
+++ b/doc/user-context.rst
@@ -99,19 +99,24 @@ or the accept header to detect that a hash was requested.
 Calculating the User Context Hash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The user context hash calculation (step 3 above) is managed by the HashGenerator.
+The user context hash calculation (step 3 above) is managed by a HashGenerator.
 Because the calculation itself will be different per application, you need to
-implement at least one ContextProvider and register that with the HashGenerator::
+implement at least one ContextProvider and register that with the DefaultHashGenerator::
 
-    use FOS\HttpCache\UserContext\HashGenerator;
+    use FOS\HttpCache\UserContext\DefaultHashGenerator;
 
-    $hashGenerator = new HashGenerator([
+    $hashGenerator = new DefaultHashGenerator([
         new IsAuthenticatedProvider(),
         new RoleProvider(),
     ]);
 
 Once all providers are registered, call ``generateHash()`` to get the hash for
 the current user context.
+
+.. note::
+
+    If you need custom logic in the hash generator you can create your own class
+    implementing the HashGenerator interface.
 
 Context Providers
 ~~~~~~~~~~~~~~~~~

--- a/src/UserContext/DefaultHashGenerator.php
+++ b/src/UserContext/DefaultHashGenerator.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\UserContext;
+
+use FOS\HttpCache\Exception\InvalidArgumentException;
+
+/**
+ * Generate a hash for a UserContext by getting all the parameters needed across all registered services.
+ */
+class DefaultHashGenerator
+{
+    /**
+     * @var ContextProvider[]
+     */
+    private $providers = [];
+
+    /**
+     * Constructor.
+     *
+     * @param ContextProvider[] $providers
+     *
+     * @throws InvalidArgumentException If no providers are supplied
+     */
+    public function __construct(array $providers)
+    {
+        if (0 === count($providers)) {
+            throw new InvalidArgumentException('You must supply at least one provider');
+        }
+
+        foreach ($providers as $provider) {
+            $this->registerProvider($provider);
+        }
+    }
+
+    /**
+     * Collect UserContext parameters and generate a hash from that.
+     *
+     * @return string The hash generated
+     */
+    public function generateHash()
+    {
+        $userContext = new UserContext();
+
+        foreach ($this->providers as $provider) {
+            $provider->updateUserContext($userContext);
+        }
+
+        $parameters = $userContext->getParameters();
+
+        // Sort by key (alphanumeric), as order should not make hash vary
+        ksort($parameters);
+
+        return hash('sha256', serialize($parameters));
+    }
+
+    /**
+     * Register a provider to be called for updating a UserContext before generating the Hash.
+     *
+     * @param ContextProvider $provider A context provider to be called to get context information about the current request
+     */
+    private function registerProvider(ContextProvider $provider)
+    {
+        $this->providers[] = $provider;
+    }
+}

--- a/src/UserContext/HashGenerator.php
+++ b/src/UserContext/HashGenerator.php
@@ -11,64 +11,13 @@
 
 namespace FOS\HttpCache\UserContext;
 
-use FOS\HttpCache\Exception\InvalidArgumentException;
-
 /**
- * Generate a hash for a UserContext by getting all the parameters needed across all registered services.
+ * Generate a hash.
  */
-class HashGenerator
+interface HashGenerator
 {
     /**
-     * @var ContextProvider[]
-     */
-    private $providers = [];
-
-    /**
-     * Constructor.
-     *
-     * @param ContextProvider[] $providers
-     *
-     * @throws InvalidArgumentException If no providers are supplied
-     */
-    public function __construct(array $providers)
-    {
-        if (0 === count($providers)) {
-            throw new InvalidArgumentException('You must supply at least one provider');
-        }
-
-        foreach ($providers as $provider) {
-            $this->registerProvider($provider);
-        }
-    }
-
-    /**
-     * Collect UserContext parameters and generate a hash from that.
-     *
      * @return string The hash generated
      */
-    public function generateHash()
-    {
-        $userContext = new UserContext();
-
-        foreach ($this->providers as $provider) {
-            $provider->updateUserContext($userContext);
-        }
-
-        $parameters = $userContext->getParameters();
-
-        // Sort by key (alphanumeric), as order should not make hash vary
-        ksort($parameters);
-
-        return hash('sha256', serialize($parameters));
-    }
-
-    /**
-     * Register a provider to be called for updating a UserContext before generating the Hash.
-     *
-     * @param ContextProvider $provider A context provider to be called to get context information about the current request
-     */
-    private function registerProvider(ContextProvider $provider)
-    {
-        $this->providers[] = $provider;
-    }
+    public function generateHash();
 }

--- a/tests/Unit/UserContext/HashGeneratorTest.php
+++ b/tests/Unit/UserContext/HashGeneratorTest.php
@@ -12,14 +12,14 @@
 namespace FOS\HttpCache\Tests\Unit\UserContext;
 
 use FOS\HttpCache\UserContext\ContextProvider;
-use FOS\HttpCache\UserContext\HashGenerator;
+use FOS\HttpCache\UserContext\DefaultHashGenerator;
 use FOS\HttpCache\UserContext\UserContext;
 
 class HashGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testGenerateHash()
     {
-        $hashGenerator = new HashGenerator([new FooProvider()]);
+        $hashGenerator = new DefaultHashGenerator([new FooProvider()]);
 
         $expectedHash = hash('sha256', serialize(['foo' => 'bar']));
 
@@ -31,7 +31,7 @@ class HashGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorError()
     {
-        new HashGenerator([]);
+        new DefaultHashGenerator([]);
     }
 }
 


### PR DESCRIPTION
I have the scenario that I do not want to cache responses for a specific group of users. Say that the administrators should always receive fresh content. 
To achieve this I created my `CustomUserContextProvider` to add some special parameters to the `UserContext`. Since the default `HashGenerator` makes a sha1 hash over all parameters and values I have no good way in writing a custom rule in my VCL to make sure the special "no-cache hash" gets a fresh response. 

By introducing an interface for the `HashGenerator` I may inject my own `HashGeneratorThatSupportsNoCacheHashes` to the `UserContextListener`. This will allow me to write an exception VCL. 