### PR TITLE
avoid sending an empty tags header on response

### DIFF
--- a/src/ResponseTagger.php
+++ b/src/ResponseTagger.php
@@ -132,6 +132,10 @@ class ResponseTagger
      */
     public function tagResponse(ResponseInterface $response, $replace = false)
     {
+        if (!$this->hasTags()) {
+            return $response;
+        }
+
         if ($replace) {
             return $response->withHeader($this->getTagsHeaderName(), $this->getTagsHeaderValue());
         }

--- a/tests/Unit/ResponseTaggerTest.php
+++ b/tests/Unit/ResponseTaggerTest.php
@@ -82,6 +82,23 @@ class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
         $tagger->tagResponse($response);
     }
 
+    public function testTagResponseNoTags()
+    {
+        /** @var TagsInterface $proxyClient */
+        $proxyClient = \Mockery::mock(TagsInterface::class)
+            ->shouldReceive('getTagsHeaderValue')->never()
+            ->getMock();
+
+        $tagger = new ResponseTagger($proxyClient);
+
+        $response = \Mockery::mock(ResponseInterface::class)
+            ->shouldReceive('withHeader')->never()
+            ->shouldReceive('withAddedHeader')->never()
+            ->getMock();
+
+        $tagger->tagResponse($response, true);
+    }
+
     public function testStrictEmptyTag()
     {
         $httpAdapter = new HttpDispatcher(['localhost'], 'localhost');


### PR DESCRIPTION
noticed while adjusting the bundle. it makes sense to unconditionally call the response tagger in an application. we should then not add an empty tag header imo.