### PR TITLE
Add sendRequest method to test client

### DIFF
--- a/src/Test/HttpClient.php
+++ b/src/Test/HttpClient.php
@@ -62,10 +62,23 @@ class HttpClient
      */
     public function getResponse($uri, array $headers, $method)
     {
+        $request = $this->createRequest($method, $uri, $headers);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * Send PSR HTTP request to your application.
+     *
+     * @param RequestInterface $request
+     *
+     * @return ResponseInterface
+     */
+    public function sendRequest(RequestInterface $request)
+    {
         // Close connections to make sure invalidation (PURGE/BAN) requests will
         // not interfere with content (GET) requests.
-        $headers['Connection'] = 'Close';
-        $request = $this->createRequest($method, $uri, $headers);
+        $request = $request->withHeader('Connection', 'Close');
 
         return $this->getHttpClient()->sendRequest($request);
     }


### PR DESCRIPTION
getResponse() only accepted URI/headers/method arguments, while sometimes you just have a (or a list of) PSR HTTP RequestInterface objects in your tests that you want to send directly.