### PR TITLE
enable hhvm builds again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 
 php:
   - 5.6
-# broken with puli discovery  - hhvm
   - 7.0
   - 7.1
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Features
   or easily implement your own caching proxy client.
 * [Test your application](http://foshttpcache.readthedocs.io/en/stable/testing-your-application.html)
   against your Varnish or NGINX setup.
-* This library is fully compatible with [HHVM](http://www.hhvm.com).
 
 Documentation
 -------------


### PR DESCRIPTION
httplug does no longer strictly depend on puli, maybe things work again now?