### PR TITLE
Improve Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: trusty
 group: edge
 language: php
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - VARNISH_VERSION=5.0.0
 
 matrix:
+  allow_failures:
+    - php: 7.2
   include:
     - php: 5.6
       env: SYMFONY_VERSION=2.7.* VARNISH_VERSION=3.0 COMPOSER_FLAGS="--prefer-lowest"
@@ -26,7 +29,7 @@ branches:
     - '/^\d+\.\d+$/'
 
 install:
-  - composer update $COMPOSER_FLAGS --prefer-source --no-interaction
+  - composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
 before_script:
   # Install Varnish
@@ -57,10 +60,10 @@ script:
   - if [[ "$DOCCHECK" = true ]]; then make -C doc spelling; fi
 
 after_script:
-  # avoid uploading the code coverage for PHP 7 and HHVM as they cannot generate it (PHPUnit dropped the old HHVM driver
-  # and the XDebug API is not implemented in HHVM 3.5) and we don't want to cancel the Scrutinizer analysis by notifying
+  # avoid uploading the code coverage for HHVM as it cannot generate it (PHPUnit dropped the old HHVM driver and the 
+  # XDebug API is not implemented in HHVM 3.5) and we don't want to cancel the Scrutinizer analysis by notifying
   # it than no coverage data is available
-  - if [[ "$TRAVIS_PHP_VERSION" != "7" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 after_failure:
   - cat /tmp/fos_nginx_error.log


### PR DESCRIPTION
With this, the coverage will be collected faster, and even under PHP 7.x; xDebug is then disabled to avoid issues.

I've also added PHP 7.2 to the matrix.