### PR TITLE
Update to PHPUnit 5.4+/6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
-        "phpunit/phpunit": "^4.5.0 || ^5.0.0 <5.4"
+        "phpunit/phpunit": "^5.4 || ^6.0"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
-        "phpunit/phpunit": "^5.4.4 || ^6.0"
+        "phpunit/phpunit": "^5.7 || ^6.0"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
-        "phpunit/phpunit": "^5.4 || ^6.0"
+        "phpunit/phpunit": "^5.4.4 || ^6.0"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,6 @@
     </filter>
 
     <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
         <listener class="\FOS\HttpCache\Test\WebServerListener" />
     </listeners>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,6 @@
     <filter>
         <whitelist>
             <directory>./src</directory>
-            <directory>./tests</directory>
         </whitelist>
     </filter>
 

--- a/src/Test/CacheAssertions.php
+++ b/src/Test/CacheAssertions.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCache\Test;
 
 use FOS\HttpCache\Test\PHPUnit\IsCacheHitConstraint;
 use FOS\HttpCache\Test\PHPUnit\IsCacheMissConstraint;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -35,7 +36,7 @@ trait CacheAssertions
      */
     public function assertMiss(ResponseInterface $response, $message = null)
     {
-        \PHPUnit_Framework_TestCase::assertThat($response, self::isCacheMiss(), $message);
+        TestCase::assertThat($response, self::isCacheMiss(), $message);
     }
 
     /**
@@ -46,7 +47,7 @@ trait CacheAssertions
      */
     public function assertHit(ResponseInterface $response, $message = null)
     {
-        \PHPUnit_Framework_TestCase::assertThat($response, self::isCacheHit(), $message);
+        TestCase::assertThat($response, self::isCacheHit(), $message);
     }
 
     public static function isCacheHit()

--- a/src/Test/EventDispatchingHttpCacheTestCase.php
+++ b/src/Test/EventDispatchingHttpCacheTestCase.php
@@ -15,6 +15,7 @@ use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\Events;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 /**
  * This test ensures that the EventDispatchingHttpCache trait is correctly used.
  */
-abstract class EventDispatchingHttpCacheTestCase extends \PHPUnit_Framework_TestCase
+abstract class EventDispatchingHttpCacheTestCase extends TestCase
 {
     /**
      * Specify the CacheInvalidationInterface HttpCache class to test.

--- a/src/Test/EventDispatchingHttpCacheTestCase.php
+++ b/src/Test/EventDispatchingHttpCacheTestCase.php
@@ -86,7 +86,7 @@ abstract class EventDispatchingHttpCacheTestCase extends TestCase
      */
     protected function setStoreMock(CacheInvalidation $httpCache, Request $request, Response $response)
     {
-        $store = $this->getMock(StoreInterface::class);
+        $store = $this->createMock(StoreInterface::class);
         $store
             ->expects($this->once())
             ->method('write')

--- a/src/Test/Legacy/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/Legacy/PHPUnit/AbstractCacheConstraint.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Test\Legacy\PHPUnit;
+
+use FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraintTrait;
+
+/**
+ * Abstract cache constraint.
+ */
+abstract class AbstractCacheConstraint extends \PHPUnit_Framework_Constraint
+{
+    use AbstractCacheConstraintTrait;
+}

--- a/src/Test/Legacy/WebServerListener.php
+++ b/src/Test/Legacy/WebServerListener.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestListener;
 
 /**
  * A PHPUnit test listener that starts and stops the PHP built-in web server.
+ * This legacy version is for PHPUnit 5.x (min 5.4.4 required, due to FC layer) 
  *
  * This listener is configured with a couple of constants from the phpunit.xml
  * file. To define constants in the phpunit file, use this syntax:

--- a/src/Test/Legacy/WebServerListener.php
+++ b/src/Test/Legacy/WebServerListener.php
@@ -16,7 +16,8 @@ use PHPUnit\Framework\TestListener;
 
 /**
  * A PHPUnit test listener that starts and stops the PHP built-in web server.
- * This legacy version is for PHPUnit 5.x (min 5.4.4 required, due to FC layer) 
+ *
+ * This legacy version is for PHPUnit 5.x (min 5.4.4 required, due to FC layer).
  *
  * This listener is configured with a couple of constants from the phpunit.xml
  * file. To define constants in the phpunit file, use this syntax:

--- a/src/Test/Legacy/WebServerListener.php
+++ b/src/Test/Legacy/WebServerListener.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Test\Legacy;
+
+use FOS\HttpCache\Test\WebServerListenerTrait;
+
+/**
+ * A PHPUnit test listener that starts and stops the PHP built-in web server.
+ *
+ * This listener is configured with a couple of constants from the phpunit.xml
+ * file. To define constants in the phpunit file, use this syntax:
+ * <php>
+ *     <const name="WEB_SERVER_HOSTNAME" value="localhost" />
+ * </php>
+ *
+ * WEB_SERVER_HOSTNAME host name of the web server (required)
+ * WEB_SERVER_PORT     port to listen on (required)
+ * WEB_SERVER_DOCROOT  path to the document root for the server (required)
+ */
+class WebServerListener implements \PHPUnit_Framework_TestListener
+{
+    /** @var WebServerListenerTrait */
+    private $trait;
+
+    public function __construct()
+    {
+        $this->trait = new WebServerListenerTrait();
+    }
+
+    /**
+     * Make sure the PHP built-in web server is running for tests with group
+     * 'webserver'.
+     */
+    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    {
+        $this->trait->startTestSuite($suite);
+    }
+
+    /**
+     *  We don't need these.
+     */
+    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    {
+    }
+
+    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    {
+    }
+
+    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    public function startTest(\PHPUnit_Framework_Test $test)
+    {
+    }
+
+    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    {
+    }
+
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    /**
+     * Get web server hostname.
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    protected function getHostName()
+    {
+        return $this->trait->getHostName();
+    }
+
+    /**
+     * Get web server port.
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    protected function getPort()
+    {
+        return $this->trait->getPort();
+    }
+
+    /**
+     * Get web server port.
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    protected function getDocRoot()
+    {
+        return $this->trait->getDocRoot();
+    }
+
+    /**
+     * Start PHP built-in web server.
+     *
+     * @return int PID
+     */
+    protected function startPhpWebServer()
+    {
+        return $this->trait->startPhpWebServer();
+    }
+
+    /**
+     * Wait for caching proxy to be started up and reachable.
+     *
+     * @param string $ip
+     * @param int    $port
+     * @param int    $timeout Timeout in milliseconds
+     *
+     * @throws \RuntimeException If proxy is not reachable within timeout
+     */
+    protected function waitFor($ip, $port, $timeout)
+    {
+        $this->trait->waitFor($ip, $port, $timeout);
+    }
+}

--- a/src/Test/Legacy/WebServerListener.php
+++ b/src/Test/Legacy/WebServerListener.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\Test\Legacy;
 
 use FOS\HttpCache\Test\WebServerListenerTrait;
+use PHPUnit\Framework\TestListener;
 
 /**
  * A PHPUnit test listener that starts and stops the PHP built-in web server.
@@ -26,7 +27,7 @@ use FOS\HttpCache\Test\WebServerListenerTrait;
  * WEB_SERVER_PORT     port to listen on (required)
  * WEB_SERVER_DOCROOT  path to the document root for the server (required)
  */
-class WebServerListener implements \PHPUnit_Framework_TestListener
+class WebServerListener implements TestListener
 {
     /** @var WebServerListenerTrait */
     private $trait;

--- a/src/Test/NginxTestCase.php
+++ b/src/Test/NginxTestCase.php
@@ -11,11 +11,13 @@
 
 namespace FOS\HttpCache\Test;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Abstract test that collects traits necessary for running tests against
  * NGINX.
  */
-abstract class NginxTestCase extends \PHPUnit_Framework_TestCase
+abstract class NginxTestCase extends TestCase
 {
     use CacheAssertions;
     use HttpCaller;

--- a/src/Test/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraint.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\Test\PHPUnit;
 
-use PHPUnit\Framework\Constraint;
+use PHPUnit\Framework\Constraint\Constraint;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('FOS\HttpCache\Test\Legacy\PHPUnit\AbstractCacheConstraint', 'FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraint');

--- a/src/Test/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraint.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('FOS\HttpCache\Test\Legacy\PHPUnit\AbstractCacheConstraint', 'FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraint');
-// Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
-// gets defined without executing the code before it and so the definition is not properly conditional)
+    // Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior
+    // (the class gets defined without executing the code before it and so the definition is not properly conditional)
 } else {
     /**
      * Abstract cache constraint.

--- a/src/Test/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraint.php
@@ -11,71 +11,18 @@
 
 namespace FOS\HttpCache\Test\PHPUnit;
 
-use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\Constraint;
 
-/**
- * Abstract cache constraint.
- */
-abstract class AbstractCacheConstraint extends \PHPUnit_Framework_Constraint
-{
-    protected $header = 'X-Cache';
-
+if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
+    class_alias('FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraint', 'FOS\HttpCache\Test\Legacy\PHPUnit\AbstractCacheConstraint');
+// Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
+// gets defined without executing the code before it and so the definition is not properly conditional)
+} else {
     /**
-     * Constructor.
-     *
-     * @param string $header Cache debug header; defaults to X-Cache-Debug
+     * Abstract cache constraint.
      */
-    public function __construct($header = null)
+    abstract class AbstractCacheConstraint extends Constraint
     {
-        if ($header) {
-            $this->header = $header;
-        }
-
-        parent::__construct();
-    }
-
-    /**
-     * Get cache header value.
-     *
-     * @return string
-     */
-    abstract public function getValue();
-
-    /**
-     * {@inheritdoc}
-     *
-     * @param Response $other The guzzle response object
-     */
-    protected function matches($other)
-    {
-        if (!$other instanceof ResponseInterface) {
-            throw new \RuntimeException(sprintf('Expected a GuzzleHttp\Psr7\Response but got %s', get_class($other)));
-        }
-        if (!$other->hasHeader($this->header)) {
-            $message = sprintf(
-                'Response has no "%s" header. Configure your caching proxy '
-                .'to set the header with cache hit/miss status.',
-                $this->header
-            );
-            if (200 !== $other->getStatusCode()) {
-                $message .= sprintf("\nStatus code of response is %s.", $other->getStatusCode());
-            }
-
-            throw new \RuntimeException($message);
-        }
-
-        return strpos((string) $other->getHeaderLine($this->header), $this->getValue()) !== false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function failureDescription($other)
-    {
-        return sprintf(
-            'response (with status code %s) %s',
-            $other->getStatusCode(),
-            $this->toString()
-        );
+        use AbstractCacheConstraintTrait;
     }
 }

--- a/src/Test/PHPUnit/AbstractCacheConstraint.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraint.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCache\Test\PHPUnit;
 use PHPUnit\Framework\Constraint;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
-    class_alias('FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraint', 'FOS\HttpCache\Test\Legacy\PHPUnit\AbstractCacheConstraint');
+    class_alias('FOS\HttpCache\Test\Legacy\PHPUnit\AbstractCacheConstraint', 'FOS\HttpCache\Test\PHPUnit\AbstractCacheConstraint');
 // Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
 // gets defined without executing the code before it and so the definition is not properly conditional)
 } else {

--- a/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Test\PHPUnit;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This trait is used to have the same code and behavior between AbstractCacheConstraint and its legacy version
+ */
+trait AbstractCacheConstraintTrait
+{
+    protected $header = 'X-Cache';
+
+    /**
+     * Constructor.
+     *
+     * @param string $header Cache debug header; defaults to X-Cache-Debug
+     */
+    public function __construct($header = null)
+    {
+        if ($header) {
+            $this->header = $header;
+        }
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param ResponseInterface $other The guzzle response object
+     */
+    public function matches($other)
+    {
+        if (!$other instanceof ResponseInterface) {
+            throw new \RuntimeException(sprintf('Expected a GuzzleHttp\Psr7\Response but got %s', get_class($other)));
+        }
+        if (!$other->hasHeader($this->header)) {
+            $message = sprintf(
+                'Response has no "%s" header. Configure your caching proxy '
+                .'to set the header with cache hit/miss status.',
+                $this->header
+            );
+            if (200 !== $other->getStatusCode()) {
+                $message .= sprintf("\nStatus code of response is %s.", $other->getStatusCode());
+            }
+
+            throw new \RuntimeException($message);
+        }
+
+        return strpos((string) $other->getHeaderLine($this->header), $this->getValue()) !== false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failureDescription($other)
+    {
+        return sprintf(
+            'response (with status code %s) %s',
+            $other->getStatusCode(),
+            $this->toString()
+        );
+    }
+}

--- a/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCache\Test\PHPUnit;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * This trait is used to have the same code and behavior between AbstractCacheConstraint and its legacy version
+ * This trait is used to have the same code and behavior between AbstractCacheConstraint and its legacy version.
  */
 trait AbstractCacheConstraintTrait
 {

--- a/src/Test/SymfonyTestCase.php
+++ b/src/Test/SymfonyTestCase.php
@@ -11,11 +11,13 @@
 
 namespace FOS\HttpCache\Test;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Abstract test that contains traits necessary for running tests against
  * Symfony HtptCache.
  */
-abstract class SymfonyTestCase extends \PHPUnit_Framework_TestCase
+abstract class SymfonyTestCase extends TestCase
 {
     use CacheAssertions;
     use HttpCaller;

--- a/src/Test/VarnishTestCase.php
+++ b/src/Test/VarnishTestCase.php
@@ -11,10 +11,12 @@
 
 namespace FOS\HttpCache\Test;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Abstract test that contains traits necessary for running tests against Varnish.
  */
-abstract class VarnishTestCase extends \PHPUnit_Framework_TestCase
+abstract class VarnishTestCase extends TestCase
 {
     use CacheAssertions;
     use HttpCaller;

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -13,7 +13,7 @@ namespace FOS\HttpCache\Test;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListener as TestListenerInterface;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 
@@ -35,7 +35,7 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
      * WEB_SERVER_PORT     port to listen on (required)
      * WEB_SERVER_DOCROOT  path to the document root for the server (required)
      */
-    class WebServerListener implements TestListener
+    class WebServerListener implements TestListenerInterface
     {
         /** @var WebServerListenerTrait */
         private $trait;

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -143,8 +143,8 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
          * Wait for caching proxy to be started up and reachable.
          *
          * @param string $ip
-         * @param int $port
-         * @param int $timeout Timeout in milliseconds
+         * @param int    $port
+         * @param int    $timeout Timeout in milliseconds
          *
          * @throws \RuntimeException If proxy is not reachable within timeout
          */

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('FOS\HttpCache\Test\Legacy\WebServerListener', 'FOS\HttpCache\Test\WebServerListener');
@@ -85,6 +86,10 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
         }
 
         public function addRiskyTest(Test $test, \Exception $e, $time)
+        {
+        }
+
+        public function addWarning(Test $test, Warning $e, $time)
         {
         }
 

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -11,179 +11,141 @@
 
 namespace FOS\HttpCache\Test;
 
-/**
- * A PHPUnit test listener that starts and stops the PHP built-in web server.
- *
- * This listener is configured with a couple of constants from the phpunit.xml
- * file. To define constants in the phpunit file, use this syntax:
- * <php>
- *     <const name="WEB_SERVER_HOSTNAME" value="localhost" />
- * </php>
- *
- * WEB_SERVER_HOSTNAME host name of the web server (required)
- * WEB_SERVER_PORT     port to listen on (required)
- * WEB_SERVER_DOCROOT  path to the document root for the server (required)
- */
-class WebServerListener implements \PHPUnit_Framework_TestListener
-{
-    /**
-     * PHP web server PID.
-     *
-     * @var int
-     */
-    protected $pid;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
 
+if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
+    class_alias('FOS\HttpCache\Test\WebServerListener', 'FOS\HttpCache\Test\Legacy\WebServerListener');
+// Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
+// gets defined without executing the code before it and so the definition is not properly conditional)
+} else {
     /**
-     * Make sure the PHP built-in web server is running for tests with group
-     * 'webserver'.
+     * A PHPUnit test listener that starts and stops the PHP built-in web server.
+     *
+     * This listener is configured with a couple of constants from the phpunit.xml
+     * file. To define constants in the phpunit file, use this syntax:
+     * <php>
+     *     <const name="WEB_SERVER_HOSTNAME" value="localhost" />
+     * </php>
+     *
+     * WEB_SERVER_HOSTNAME host name of the web server (required)
+     * WEB_SERVER_PORT     port to listen on (required)
+     * WEB_SERVER_DOCROOT  path to the document root for the server (required)
      */
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    class WebServerListener implements TestListener
     {
-        // Only run on PHP >= 5.4 as PHP below that and HHVM don't have a
-        // built-in web server
-        if (defined('HHVM_VERSION')) {
-            return;
+        /** @var WebServerListenerTrait */
+        private $trait;
+
+        public function __construct()
+        {
+            $this->trait = new WebServerListenerTrait();
         }
 
-        if (!in_array('webserver', $suite->getGroups()) || null !== $this->pid) {
-            return;
+        /**
+         * Make sure the PHP built-in web server is running for tests with group
+         * 'webserver'.
+         */
+        public function startTestSuite(TestSuite $suite)
+        {
+            $this->trait->startTestSuite($suite);
         }
 
-        $this->pid = $pid = $this->startPhpWebServer();
-
-        register_shutdown_function(function () use ($pid) {
-            exec('kill '.$pid);
-        });
-    }
-
-    /**
-     *  We don't need these.
-     */
-    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
-    {
-    }
-
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
-    }
-
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function startTest(\PHPUnit_Framework_Test $test)
-    {
-    }
-
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
-    {
-    }
-
-    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    /**
-     * Get web server hostname.
-     *
-     * @throws \Exception
-     *
-     * @return string
-     */
-    protected function getHostName()
-    {
-        if (!defined('WEB_SERVER_HOSTNAME')) {
-            throw new \Exception('Set WEB_SERVER_HOSTNAME in your phpunit.xml');
+        /**
+         *  We don't need these.
+         */
+        public function endTestSuite(TestSuite $suite)
+        {
         }
 
-        return WEB_SERVER_HOSTNAME;
-    }
-
-    /**
-     * Get web server port.
-     *
-     * @throws \Exception
-     *
-     * @return int
-     */
-    protected function getPort()
-    {
-        if (!defined('WEB_SERVER_PORT')) {
-            throw new \Exception('Set WEB_SERVER_PORT in your phpunit.xml');
+        public function addError(Test $test, \Exception $e, $time)
+        {
         }
 
-        return WEB_SERVER_PORT;
-    }
-
-    /**
-     * Get web server port.
-     *
-     * @throws \Exception
-     *
-     * @return int
-     */
-    protected function getDocRoot()
-    {
-        if (!defined('WEB_SERVER_DOCROOT')) {
-            throw new \Exception('Set WEB_SERVER_DOCROOT in your phpunit.xml');
+        public function addFailure(Test $test, AssertionFailedError $e, $time)
+        {
         }
 
-        return WEB_SERVER_DOCROOT;
-    }
-
-    /**
-     * Start PHP built-in web server.
-     *
-     * @return int PID
-     */
-    protected function startPhpWebServer()
-    {
-        $command = sprintf(
-            'php -S %s:%d -t %s >/dev/null 2>&1 & echo $!',
-            '127.0.0.1', // on travis, localhost is not 127.0.0.1 but IPv6 ::1
-            $this->getPort(),
-            $this->getDocRoot()
-        );
-        exec($command, $output);
-
-        $this->waitFor($this->getHostName(), $this->getPort(), 2000);
-
-        return $output[0];
-    }
-
-    /**
-     * Wait for caching proxy to be started up and reachable.
-     *
-     * @param string $ip
-     * @param int    $port
-     * @param int    $timeout Timeout in milliseconds
-     *
-     * @throws \RuntimeException If proxy is not reachable within timeout
-     */
-    protected function waitFor($ip, $port, $timeout)
-    {
-        for ($i = 0; $i < $timeout; ++$i) {
-            if (@fsockopen($ip, $port)) {
-                return;
-            }
-
-            usleep(1000);
+        public function addIncompleteTest(Test $test, \Exception $e, $time)
+        {
         }
 
-        throw new \RuntimeException(
-            sprintf(
-                'Webserver cannot be reached at %s:%s',
-                $ip,
-                $port
-            )
-        );
+        public function addSkippedTest(Test $test, \Exception $e, $time)
+        {
+        }
+
+        public function startTest(Test $test)
+        {
+        }
+
+        public function endTest(Test $test, $time)
+        {
+        }
+
+        public function addRiskyTest(Test $test, \Exception $e, $time)
+        {
+        }
+
+        /**
+         * Get web server hostname.
+         *
+         * @throws \Exception
+         *
+         * @return string
+         */
+        protected function getHostName()
+        {
+            return $this->trait->getHostName();
+        }
+
+        /**
+         * Get web server port.
+         *
+         * @throws \Exception
+         *
+         * @return int
+         */
+        protected function getPort()
+        {
+            return $this->trait->getPort();
+        }
+
+        /**
+         * Get web server port.
+         *
+         * @throws \Exception
+         *
+         * @return int
+         */
+        protected function getDocRoot()
+        {
+            return $this->trait->getDocRoot();
+        }
+
+        /**
+         * Start PHP built-in web server.
+         *
+         * @return int PID
+         */
+        protected function startPhpWebServer()
+        {
+            return $this->trait->startPhpWebServer();
+        }
+
+        /**
+         * Wait for caching proxy to be started up and reachable.
+         *
+         * @param string $ip
+         * @param int $port
+         * @param int $timeout Timeout in milliseconds
+         *
+         * @throws \RuntimeException If proxy is not reachable within timeout
+         */
+        protected function waitFor($ip, $port, $timeout)
+        {
+            $this->trait->waitFor($ip, $port, $timeout);
+        }
     }
 }

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -19,8 +19,8 @@ use PHPUnit\Framework\Warning;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('FOS\HttpCache\Test\Legacy\WebServerListener', 'FOS\HttpCache\Test\WebServerListener');
-// Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
-// gets defined without executing the code before it and so the definition is not properly conditional)
+    // Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior
+    //(the class gets defined without executing the code before it and so the definition is not properly conditional)
 } else {
     /**
      * A PHPUnit test listener that starts and stops the PHP built-in web server.

--- a/src/Test/WebServerListener.php
+++ b/src/Test/WebServerListener.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
-    class_alias('FOS\HttpCache\Test\WebServerListener', 'FOS\HttpCache\Test\Legacy\WebServerListener');
+    class_alias('FOS\HttpCache\Test\Legacy\WebServerListener', 'FOS\HttpCache\Test\WebServerListener');
 // Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
 // gets defined without executing the code before it and so the definition is not properly conditional)
 } else {

--- a/src/Test/WebServerListenerTrait.php
+++ b/src/Test/WebServerListenerTrait.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Test;
 
 /**
- * This fake trait is used to have the same code and behavior between WebServerListener and its legacy version
+ * This fake trait is used to have the same code and behavior between WebServerListener and its legacy version.
  */
 class WebServerListenerTrait
 {

--- a/src/Test/WebServerListenerTrait.php
+++ b/src/Test/WebServerListenerTrait.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Test;
+
+/**
+ * This fake trait is used to have the same code and behavior between WebServerListener and its legacy version
+ */
+class WebServerListenerTrait
+{
+    /**
+     * PHP web server PID.
+     *
+     * @var int
+     */
+    protected $pid;
+
+    /**
+     * Make sure the PHP built-in web server is running for tests with group
+     * 'webserver'.
+     */
+    public function startTestSuite($suite)
+    {
+        // Only run on PHP >= 5.4 as PHP below that and HHVM don't have a
+        // built-in web server
+        if (defined('HHVM_VERSION')) {
+            return;
+        }
+
+        if (!in_array('webserver', $suite->getGroups()) || null !== $this->pid) {
+            return;
+        }
+
+        $this->pid = $pid = $this->startPhpWebServer();
+
+        register_shutdown_function(function () use ($pid) {
+            exec('kill '.$pid);
+        });
+    }
+
+    /**
+     * Get web server hostname.
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    public function getHostName()
+    {
+        if (!defined('WEB_SERVER_HOSTNAME')) {
+            throw new \Exception('Set WEB_SERVER_HOSTNAME in your phpunit.xml');
+        }
+
+        return WEB_SERVER_HOSTNAME;
+    }
+
+    /**
+     * Get web server port.
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    public function getPort()
+    {
+        if (!defined('WEB_SERVER_PORT')) {
+            throw new \Exception('Set WEB_SERVER_PORT in your phpunit.xml');
+        }
+
+        return WEB_SERVER_PORT;
+    }
+
+    /**
+     * Get web server port.
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    public function getDocRoot()
+    {
+        if (!defined('WEB_SERVER_DOCROOT')) {
+            throw new \Exception('Set WEB_SERVER_DOCROOT in your phpunit.xml');
+        }
+
+        return WEB_SERVER_DOCROOT;
+    }
+
+    /**
+     * Start PHP built-in web server.
+     *
+     * @return int PID
+     */
+    public function startPhpWebServer()
+    {
+        $command = sprintf(
+            'php -S %s:%d -t %s >/dev/null 2>&1 & echo $!',
+            '127.0.0.1', // on travis, localhost is not 127.0.0.1 but IPv6 ::1
+            $this->getPort(),
+            $this->getDocRoot()
+        );
+        exec($command, $output);
+
+        $this->waitFor($this->getHostName(), $this->getPort(), 2000);
+
+        return $output[0];
+    }
+
+    /**
+     * Wait for caching proxy to be started up and reachable.
+     *
+     * @param string $ip
+     * @param int    $port
+     * @param int    $timeout Timeout in milliseconds
+     *
+     * @throws \RuntimeException If proxy is not reachable within timeout
+     */
+    public function waitFor($ip, $port, $timeout)
+    {
+        for ($i = 0; $i < $timeout; ++$i) {
+            if (@fsockopen($ip, $port)) {
+                return;
+            }
+
+            usleep(1000);
+        }
+
+        throw new \RuntimeException(
+            sprintf(
+                'Webserver cannot be reached at %s:%s',
+                $ip,
+                $port
+            )
+        );
+    }
+}

--- a/tests/Functional/ProxyClient/HttpDispatcherTest.php
+++ b/tests/Functional/ProxyClient/HttpDispatcherTest.php
@@ -16,8 +16,9 @@ use FOS\HttpCache\Exception\ProxyResponseException;
 use FOS\HttpCache\Exception\ProxyUnreachableException;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use Http\Discovery\MessageFactoryDiscovery;
+use PHPUnit\Framework\TestCase;
 
-class HttpDispatcherTest extends \PHPUnit_Framework_TestCase
+class HttpDispatcherTest extends TestCase
 {
     public function testNetworkError()
     {

--- a/tests/Functional/ProxyClient/RefreshAssertions.php
+++ b/tests/Functional/ProxyClient/RefreshAssertions.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\Tests\Functional\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use PHPUnit\Framework\Assert;
 
 /**
  * Assertions that do the refresh operations.
@@ -37,9 +38,9 @@ trait RefreshAssertions
         $originalTimestamp = (float) (string) $response->getBody();
         $refreshedTimestamp = (float) (string) $refreshed->getBody();
 
-        \PHPUnit_Framework_Assert::assertThat(
+        Assert::assertThat(
             $refreshedTimestamp,
-            \PHPUnit_Framework_Assert::greaterThan($originalTimestamp)
+            Assert::greaterThan($originalTimestamp)
         );
     }
 

--- a/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
+++ b/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\HttpCache\Tests\Functional\Varnish;
+namespace FOS\HttpCache\Tests\Functional\Symfony;
 
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
@@ -18,6 +18,7 @@ use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\RefreshListener;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
@@ -27,7 +28,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 /**
  * @group symfony
  */
-class EventDispatchingHttpCacheTest extends \PHPUnit_Framework_TestCase
+class EventDispatchingHttpCacheTest extends TestCase
 {
     public function testEventListeners()
     {

--- a/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
+++ b/tests/Functional/Symfony/EventDispatchingHttpCacheTest.php
@@ -18,6 +18,7 @@ use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\RefreshListener;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,6 +31,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class EventDispatchingHttpCacheTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testEventListeners()
     {
         $request = new Request();

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -25,6 +25,7 @@ use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\ProxyClient\Varnish;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\RequestException;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -34,6 +35,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class CacheInvalidatorTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testSupportsTrue()
     {
         /** @var MockInterface|Varnish $proxyClient */

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -25,14 +25,14 @@ use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\ProxyClient\Varnish;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\RequestException;
-use Mockery\Mock;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase
+class CacheInvalidatorTest extends TestCase
 {
     public function testSupportsTrue()
     {

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -271,7 +271,7 @@ class CacheInvalidatorTest extends TestCase
         $cacheInvalidator = new CacheInvalidator($proxyClient);
         $eventDispatcher = new EventDispatcher();
         $cacheInvalidator->setEventDispatcher($eventDispatcher);
-        $this->setExpectedException(\Exception::class);
+        $this->expectException(\Exception::class);
         $cacheInvalidator->setEventDispatcher($eventDispatcher);
     }
 }

--- a/tests/Unit/Exception/ExceptionCollectionTest.php
+++ b/tests/Unit/Exception/ExceptionCollectionTest.php
@@ -9,11 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\HttpCache\Tests\Unit\ProxyClient;
+namespace FOS\HttpCache\Tests\Unit\Exception;
 
 use FOS\HttpCache\Exception\ExceptionCollection;
+use PHPUnit\Framework\TestCase;
 
-class ExceptionCollectionTest extends \PHPUnit_Framework_TestCase
+class ExceptionCollectionTest extends TestCase
 {
     public function testCollectionConstructor()
     {

--- a/tests/Unit/ProxyClient/HttpDispatcherTest.php
+++ b/tests/Unit/ProxyClient/HttpDispatcherTest.php
@@ -25,10 +25,11 @@ use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Http\Mock\Client;
 use Http\Promise\Promise;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class HttpDispatcherTest extends \PHPUnit_Framework_TestCase
+class HttpDispatcherTest extends TestCase
 {
     /**
      * Mock HTTP client.

--- a/tests/Unit/ProxyClient/HttpDispatcherTest.php
+++ b/tests/Unit/ProxyClient/HttpDispatcherTest.php
@@ -25,12 +25,15 @@ use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Http\Mock\Client;
 use Http\Promise\Promise;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpDispatcherTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * Mock HTTP client.
      *

--- a/tests/Unit/ProxyClient/HttpProxyClientTest.php
+++ b/tests/Unit/ProxyClient/HttpProxyClientTest.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Varnish;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +22,8 @@ use PHPUnit\Framework\TestCase;
  */
 class HttpProxyClientTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testFlush()
     {
         /** @var HttpDispatcher|MockInterface $httpDispatcher */

--- a/tests/Unit/ProxyClient/HttpProxyClientTest.php
+++ b/tests/Unit/ProxyClient/HttpProxyClientTest.php
@@ -14,11 +14,12 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Varnish;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Testing the base methods of the proxy client, using the Varnish client as concrete class.
  */
-class HttpProxyClientTest extends \PHPUnit_Framework_TestCase
+class HttpProxyClientTest extends TestCase
 {
     public function testFlush()
     {

--- a/tests/Unit/ProxyClient/MultiplexerClientTest.php
+++ b/tests/Unit/ProxyClient/MultiplexerClientTest.php
@@ -17,8 +17,9 @@ use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\ProxyClient\MultiplexerClient;
 use FOS\HttpCache\ProxyClient\ProxyClient;
+use PHPUnit\Framework\TestCase;
 
-class MultiplexerClientTest extends \PHPUnit_Framework_TestCase
+class MultiplexerClientTest extends TestCase
 {
     public function testBan()
     {

--- a/tests/Unit/ProxyClient/MultiplexerClientTest.php
+++ b/tests/Unit/ProxyClient/MultiplexerClientTest.php
@@ -17,10 +17,13 @@ use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\ProxyClient\MultiplexerClient;
 use FOS\HttpCache\ProxyClient\ProxyClient;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 
 class MultiplexerClientTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testBan()
     {
         $headers = ['Header1' => 'Header1-Value'];

--- a/tests/Unit/ProxyClient/NoopTest.php
+++ b/tests/Unit/ProxyClient/NoopTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Noop;
+use PHPUnit\Framework\TestCase;
 
-class NoopTest extends \PHPUnit_Framework_TestCase
+class NoopTest extends TestCase
 {
     /**
      * @var Noop

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -14,9 +14,10 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Symfony;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
-class SymfonyTest extends \PHPUnit_Framework_TestCase
+class SymfonyTest extends TestCase
 {
     /**
      * @var HttpDispatcher|MockInterface

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -13,12 +13,15 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Symfony;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 class SymfonyTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var HttpDispatcher|MockInterface
      */

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -13,12 +13,15 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Varnish;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 class VarnishTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var HttpDispatcher|MockInterface
      */

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -14,9 +14,10 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Varnish;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
-class VarnishTest extends \PHPUnit_Framework_TestCase
+class VarnishTest extends TestCase
 {
     /**
      * @var HttpDispatcher|MockInterface

--- a/tests/Unit/ResponseTaggerTest.php
+++ b/tests/Unit/ResponseTaggerTest.php
@@ -114,7 +114,7 @@ class ResponseTaggerTest extends TestCase
 
         $tagHandler = new ResponseTagger(['header_formatter' => $headerFormatter, 'strict' => true]);
 
-        $this->setExpectedException(InvalidTagException::class);
+        $this->expectException(InvalidTagException::class);
         $tagHandler->addTags(['post-1', false]);
     }
 

--- a/tests/Unit/ResponseTaggerTest.php
+++ b/tests/Unit/ResponseTaggerTest.php
@@ -15,9 +15,10 @@ use FOS\HttpCache\Exception\InvalidTagException;
 use FOS\HttpCache\ResponseTagger;
 use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
 use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
-class ResponseTaggerTest extends \PHPUnit_Framework_TestCase
+class ResponseTaggerTest extends TestCase
 {
     public function testDefaultFormatter()
     {

--- a/tests/Unit/ResponseTaggerTest.php
+++ b/tests/Unit/ResponseTaggerTest.php
@@ -15,11 +15,14 @@ use FOS\HttpCache\Exception\InvalidTagException;
 use FOS\HttpCache\ResponseTagger;
 use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
 use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
 class ResponseTaggerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testDefaultFormatter()
     {
         $tagger = new ResponseTagger();

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomTtlListenerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var CacheInvalidation|MockInterface
      */

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -15,10 +15,11 @@ use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class CustomTtlListenerTest extends \PHPUnit_Framework_TestCase
+class CustomTtlListenerTest extends TestCase
 {
     /**
      * @var CacheInvalidation|MockInterface

--- a/tests/Unit/SymfonyCache/DebugListenerTest.php
+++ b/tests/Unit/SymfonyCache/DebugListenerTest.php
@@ -14,12 +14,15 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\DebugListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class DebugListenerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/tests/Unit/SymfonyCache/DebugListenerTest.php
+++ b/tests/Unit/SymfonyCache/DebugListenerTest.php
@@ -14,10 +14,11 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\DebugListener;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class DebugListenerTest extends \PHPUnit_Framework_TestCase
+class DebugListenerTest extends TestCase
 {
     /**
      * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -15,12 +15,13 @@ use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 
-class PurgeListenerTest extends \PHPUnit_Framework_TestCase
+class PurgeListenerTest extends TestCase
 {
     /**
      * This tests a sanity check in the AbstractControlledListener.

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,6 +24,8 @@ use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 
 class PurgeListenerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * This tests a sanity check in the AbstractControlledListener.
      *

--- a/tests/Unit/SymfonyCache/RefreshListenerTest.php
+++ b/tests/Unit/SymfonyCache/RefreshListenerTest.php
@@ -28,7 +28,7 @@ class RefreshListenerTest extends TestCase
 
     public function setUp()
     {
-        $this->kernel = $this->getMock(CacheInvalidation::class);
+        $this->kernel = $this->createMock(CacheInvalidation::class);
     }
 
     public function testRefreshAllowed()

--- a/tests/Unit/SymfonyCache/RefreshListenerTest.php
+++ b/tests/Unit/SymfonyCache/RefreshListenerTest.php
@@ -14,11 +14,12 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\RefreshListener;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 
-class RefreshListenerTest extends \PHPUnit_Framework_TestCase
+class RefreshListenerTest extends TestCase
 {
     /**
      * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/SymfonyCache/UserContextListenerTest.php
+++ b/tests/Unit/SymfonyCache/UserContextListenerTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UserContextListenerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var CacheInvalidation|MockInterface
      */

--- a/tests/Unit/SymfonyCache/UserContextListenerTest.php
+++ b/tests/Unit/SymfonyCache/UserContextListenerTest.php
@@ -15,10 +15,11 @@ use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class UserContextListenerTest extends \PHPUnit_Framework_TestCase
+class UserContextListenerTest extends TestCase
 {
     /**
      * @var CacheInvalidation|MockInterface

--- a/tests/Unit/TagHeaderFormatter/CommaSeparatedTagHeaderFormatterTest.php
+++ b/tests/Unit/TagHeaderFormatter/CommaSeparatedTagHeaderFormatterTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\TagHeaderFormatter;
 
 use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
+use PHPUnit\Framework\TestCase;
 
-class CommaSeparatedTagHeaderFormatterTest extends \PHPUnit_Framework_TestCase
+class CommaSeparatedTagHeaderFormatterTest extends TestCase
 {
     public function testGetTagsHeaderName()
     {

--- a/tests/Unit/Test/NginxTestTest.php
+++ b/tests/Unit/Test/NginxTestTest.php
@@ -9,12 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\HttpCache\Tests\Unit\Test\Proxy;
+namespace FOS\HttpCache\Tests\Unit\Test;
 
 use FOS\HttpCache\Test\NginxTest;
 use FOS\HttpCache\Test\Proxy\NginxProxy;
+use PHPUnit\Framework\TestCase;
 
-class NginxTestTest extends \PHPUnit_Framework_TestCase
+class NginxTestTest extends TestCase
 {
     use NginxTest;
 

--- a/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
@@ -11,7 +11,9 @@
 
 namespace FOS\HttpCache\Tests\Unit\Test\PHPUnit;
 
-abstract class AbstractCacheConstraintTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractCacheConstraintTest extends TestCase
 {
     protected function getResponseMock()
     {

--- a/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
@@ -11,10 +11,13 @@
 
 namespace FOS\HttpCache\Tests\Unit\Test\PHPUnit;
 
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractCacheConstraintTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     protected function getResponseMock()
     {
         $mock = \Mockery::mock(

--- a/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
@@ -26,7 +26,7 @@ class IsCacheHitConstraintTest extends AbstractCacheConstraintTest
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage Failed asserting that response (with status code 500) is a cache hit
      */
     public function testMatches()

--- a/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
@@ -13,6 +13,11 @@ namespace FOS\HttpCache\Tests\Unit\Test\PHPUnit;
 
 use FOS\HttpCache\Test\PHPUnit\IsCacheHitConstraint;
 
+// phpunit 5 has forward compatibility classes but missed this one
+if (!class_exists('\PHPUnit\Framework\ExpectationFailedException')) {
+    class_alias('\PHPUnit_Framework_ExpectationFailedException', '\PHPUnit\Framework\ExpectationFailedException');
+}
+
 class IsCacheHitConstraintTest extends AbstractCacheConstraintTest
 {
     /**

--- a/tests/Unit/Test/PHPUnit/IsCacheMissConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/IsCacheMissConstraintTest.php
@@ -26,7 +26,7 @@ class IsCacheMissConstraintTest extends AbstractCacheConstraintTest
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      * @expectedExceptionMessage Failed asserting that response (with status code 200) is a cache miss
      */
     public function testMatches()

--- a/tests/Unit/Test/PHPUnit/IsCacheMissConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/IsCacheMissConstraintTest.php
@@ -13,6 +13,11 @@ namespace FOS\HttpCache\Tests\Unit\Test\PHPUnit;
 
 use FOS\HttpCache\Test\PHPUnit\IsCacheMissConstraint;
 
+// phpunit 5 has forward compatibility classes but missed this one
+if (!class_exists('\PHPUnit\Framework\ExpectationFailedException')) {
+    class_alias('\PHPUnit_Framework_ExpectationFailedException', '\PHPUnit\Framework\ExpectationFailedException');
+}
+
 class IsCacheMissConstraintTest extends AbstractCacheConstraintTest
 {
     /**

--- a/tests/Unit/Test/Proxy/AbstractProxyTest.php
+++ b/tests/Unit/Test/Proxy/AbstractProxyTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\Test\Proxy;
 
 use FOS\HttpCache\Test\Proxy\AbstractProxy;
+use PHPUnit\Framework\TestCase;
 
-class AbstractProxyTest extends \PHPUnit_Framework_TestCase
+class AbstractProxyTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Test/Proxy/SymfonyProxyTest.php
+++ b/tests/Unit/Test/Proxy/SymfonyProxyTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\Test\Proxy;
 
 use FOS\HttpCache\Test\Proxy\SymfonyProxy;
+use PHPUnit\Framework\TestCase;
 
-class SymfonyProxyTest extends \PHPUnit_Framework_TestCase
+class SymfonyProxyTest extends TestCase
 {
     public function testStart()
     {

--- a/tests/Unit/Test/Proxy/VarnishProxyTest.php
+++ b/tests/Unit/Test/Proxy/VarnishProxyTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\Test\Proxy;
 
 use FOS\HttpCache\Test\Proxy\VarnishProxy;
+use PHPUnit\Framework\TestCase;
 
-class VarnishProxyTest extends \PHPUnit_Framework_TestCase
+class VarnishProxyTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Unit/Test/VarnishTestTest.php
+++ b/tests/Unit/Test/VarnishTestTest.php
@@ -9,12 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\HttpCache\Tests\Unit\Test\Proxy;
+namespace FOS\HttpCache\Tests\Unit\Test;
 
 use FOS\HttpCache\Test\Proxy\VarnishProxy;
 use FOS\HttpCache\Test\VarnishTest;
+use PHPUnit\Framework\TestCase;
 
-class VarnishTestTest extends \PHPUnit_Framework_TestCase
+class VarnishTestTest extends TestCase
 {
     use VarnishTest;
 

--- a/tests/Unit/UserContext/HashGeneratorTest.php
+++ b/tests/Unit/UserContext/HashGeneratorTest.php
@@ -14,8 +14,9 @@ namespace FOS\HttpCache\Tests\Unit\UserContext;
 use FOS\HttpCache\UserContext\ContextProvider;
 use FOS\HttpCache\UserContext\DefaultHashGenerator;
 use FOS\HttpCache\UserContext\UserContext;
+use PHPUnit\Framework\TestCase;
 
-class HashGeneratorTest extends \PHPUnit_Framework_TestCase
+class HashGeneratorTest extends TestCase
 {
     public function testGenerateHash()
     {

--- a/tests/Unit/UserContext/UserContextTest.php
+++ b/tests/Unit/UserContext/UserContextTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCache\Tests\Unit\UserContext;
 
 use FOS\HttpCache\UserContext\UserContext;
+use PHPUnit\Framework\TestCase;
 
-class UserContextTest extends \PHPUnit_Framework_TestCase
+class UserContextTest extends TestCase
 {
     public function testAddParameter()
     {


### PR DESCRIPTION
As discussed in #363, this PR aims to migrate to PHPUnit 5.4, so it will be also cross compatible with PHPUnit 6.

The hardest part was migrating the `AbstractCacheConstraint` and the `WebServerListener` classes, but @lyrixx pointed us toward a nice trick that was used in the symfony/phpunit-bridge to solve the same issue.