### PR TITLE
Set the default value of queue in proxy client to an empty array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
 
 env:
   - VARNISH_VERSION=4.0
@@ -28,7 +30,7 @@ branches:
 before_script:
   # Install deps
   - composer update $COMPOSER_FLAGS --dev --prefer-source --no-interaction
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '7' ]; then wget https://phar.phpunit.de/phpunit-5.7.phar; fi"
+  - bash -c "if [[ '$TRAVIS_PHP_VERSION' == '7.'* ]] ; then wget https://phar.phpunit.de/phpunit-5.7.phar; fi"
   # Install Varnish
   - curl http://repo.varnish-cache.org/debian/GPG-key.txt | sudo apt-key add -
   - echo "deb http://repo.varnish-cache.org/ubuntu/ precise varnish-${VARNISH_VERSION}" | sudo tee -a /etc/apt/sources.list
@@ -42,7 +44,7 @@ before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = 'hhvm' ]; then ./tests/ci/install-apache-hhvm.sh; fi"
 
 script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '7' ]; then php phpunit-5.7.phar --coverage-clover=coverage.clover; fi"
+  - bash -c "if [[ '$TRAVIS_PHP_VERSION' == '7.'* ]] ; then php phpunit-5.7.phar --coverage-clover=coverage.clover; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' \< '7' ]; then phpunit --coverage-clover=coverage.clover; fi"
   - make -C doc SPHINXOPTS='-nW' html
   - make -C doc spelling

--- a/src/ProxyClient/AbstractProxyClient.php
+++ b/src/ProxyClient/AbstractProxyClient.php
@@ -48,7 +48,7 @@ abstract class AbstractProxyClient implements ProxyClientInterface
      *
      * @var array|RequestInterface[]
      */
-    private $queue;
+    private $queue = array();
 
     /**
      * Constructor.


### PR DESCRIPTION
PHP 7.2 throws a warning when `count` is called with a `null` argument which breaks Symfony apps (and presumably others too), so this makes sure the `AbstractProxyClient::$queue` is never `null` when counting it in `AbstractProxyClient::flush` method.