### PR TITLE
Symfony taggable cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 * Upgraded phpunit to 5.7 / 6. If you use anything from the FOS\HttpCache\Test
   namespace you need to update your project to use phpunit 6 (or 5.7, if you
   are using PHP 5.6).
+* Added a `TaggableStore` and a `PurgeTagsListener` that adds support for chache
+  invalidation based on tags for the Symfony reverse proxy (`HttpCache`). The
+  `TaggableStore` also supports pruning the cache directory.
 
 2.0.2
 -----

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
         "symfony/lock": "^3.4@dev",
-        "symfony/cache": "^3.2",
+        "symfony/cache": "^3.4@dev",
         "phpunit/phpunit": "^5.7 || ^6.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
         "php-http/mock-client": "^0.3.2",
         "symfony/process": "^2.3||^3.0",
         "symfony/http-kernel": "^2.3||^3.0",
+        "symfony/lock": "^3.4@dev",
+        "symfony/cache": "^3.2",
         "phpunit/phpunit": "^5.7 || ^6.0"
     },
     "suggest": {

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -24,7 +24,7 @@ Client        Purge   Refresh Ban     Tagging
 ============= ======= ======= ======= =======
 Varnish       ✓       ✓       ✓       ✓
 NGINX         ✓       ✓
-Symfony Cache ✓       ✓
+Symfony Cache ✓       ✓               ✓
 Noop          ✓       ✓       ✓       ✓
 Multiplexer   ✓       ✓       ✓       ✓
 ============= ======= ======= ======= =======

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -19,9 +19,20 @@ The response tagger uses an instance of ``TagHeaderFormatter`` to know the
 header name used to mark tags on the content and to format the tags into the
 correct header value. This library ships with a
 ``CommaSeparatedTagHeaderFormatter`` that formats an array of tags into a
-comma-separated list. This format is expected for invalidation with the
-Varnish reverse proxy. When using the default settings, everything is created
-automatically and the ``X-Cache-Tags`` header will be used::
+comma-separated list. What kind of format you need obviously depends on what
+proxy you use and how this proxy is configured (if it even can be configured).
+It is important you do understand that the ``ResponseTagger`` is not directly
+linked to the proxy configuration so you are the one that has to make sure, they
+match. Don't worry too much though, the default settings will work out of the box
+and if you really need to adjust formatting, header names etc. you likely have
+some special environment that needs special adjustments. So for now, just remember
+you can configure all the stuff but you don't have to.
+
+For example, the :doc:`default configuration of Varnish <varnish-configuration>` in
+this documentation requires the header to contain a comma-separated list of tags
+and the default examples use the header ``X-Cache-Tags``. If you don't change
+the ``TagHeaderFormatter`` nor the header name, everything will be created
+automatically and work out of the box for you::
 
     use FOS\HttpCache\ResponseTagger;
 
@@ -29,9 +40,9 @@ automatically and the ``X-Cache-Tags`` header will be used::
 
 .. _response_tagger_optional_parameters:
 
-If you need a different behavior, you can provide your own implementation of
-the ``TagHeaderFormatter`` interface. But be aware that your
-:ref:`Varnish configuration <varnish_tagging>` has to match with the tag on the response.
+As explained already, if you need a different behavior, you can provide your own
+implementation of the ``TagHeaderFormatter`` interface. But again, be aware that your
+:doc:`proxy configuration <proxy-configuration>` has to match with the response.
 For example, to use a different header name::
 
     use FOS\HttpCache\ResponseTagger;

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -40,9 +40,9 @@ automatically and work out of the box for you::
 
 .. _response_tagger_optional_parameters:
 
-As explained already, if you need a different behavior, you can provide your own
-implementation of the ``TagHeaderFormatter`` interface. But again, be aware that your
-:doc:`proxy configuration <proxy-configuration>` has to match with the response.
+If you need a different behavior, you can provide your own
+``TagHeaderFormatter`` instance. Be aware that your
+:doc:`proxy configuration <proxy-configuration>` has to match the response.
 For example, to use a different header name::
 
     use FOS\HttpCache\ResponseTagger;

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -300,7 +300,7 @@ filling up your file system without ever cleaning up expired cache entries.
 The `TaggableStore` counts all the cache write operations (so fetching items
 from the cache is not slowed down) and after reaching a configurable
 threshold (default `500`), it prunes expired data. If you want to disable
-pruning, you can set the threshold to `0`.
+pruning, you can set the option `prune_threshold` to `0`.
 This means that after every `500` HTTP cache writes, your file system directory
 will be cleaned up and thus kept in good shape.
 You can configure the prune threshold by providing a different threshold as

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -275,40 +275,40 @@ The TaggableStore
 
 .. versionadded:: 2.1
 
-    The `TaggableStore` has been added in version 2.1.
+    The ``TaggableStore`` has been added in version 2.1.
 
 .. warning::
 
-    You need at least versions 3.4 of `symfony/cache` and `symfony/lock`
-    to use this feature! Add the following lines to your `composer.json` and run
-    `composer update`::
+    You need at least versions 3.4 of ``symfony/cache`` and ``symfony/lock``
+    to use this feature! Add the following lines to your ``composer.json`` and run
+    ``composer update``::
 
-    "symfony/lock": "^3.4",
-    "symfony/cache": "^3.4",
+        "symfony/lock": "^3.4",
+        "symfony/cache": "^3.4",
 
 
-Symfony's `HttpCache` does not support tags based cache invalidation by default.
-However, this library ships with a `TaggableStore` and a corresponding
-`PurgeTagsListener` which provide this functionality.
+Symfony's ``HttpCache`` does not support tags based cache invalidation by default.
+However, this library ships with a ``TaggableStore`` and a corresponding
+``PurgeTagsListener`` which provide this functionality.
 Even if you do not want to invalidate cache entries by tags, you might be
-interested in using the `TaggableStore` instead of the default `Store`
+interested in using the ``TaggableStore`` instead of the default ``Store``
 implementation Symfony ships with.
 
-That's because `TaggableStore` also prunes expired entries on a regular basis
-which is something the default `Store` does not. The default `Store` keeps
+That's because ``TaggableStore`` also prunes expired entries on a regular basis
+which is something the default ``Store`` does not. The default ``Store`` keeps
 filling up your file system without ever cleaning up expired cache entries.
-The `TaggableStore` counts all the cache write operations (so fetching items
+The ``TaggableStore`` counts all the cache write operations (so fetching items
 from the cache is not slowed down) and after reaching a configurable
-threshold (default `500`), it prunes expired data. If you want to disable
-pruning, you can set the option `prune_threshold` to `0`.
-This means that after every `500` HTTP cache writes, your file system directory
+threshold (default ``500``), it prunes expired data. If you want to disable
+pruning, you can set the option ``prune_threshold`` to ``0``.
+This means that after every ``500`` HTTP cache writes, your file system directory
 will be cleaned up and thus kept in good shape.
 You can configure the prune threshold by providing a different threshold as
-second argument to the constructor of `TaggableStore`.
+second argument to the constructor of ``TaggableStore``.
 
-For this to work, you have to use the `TaggableStore` in your kernel.
+For this to work, you have to use the ``TaggableStore`` in your kernel.
 If you want support for tag based cache invalidation, you also need to register
-the `PurgeListener` so your `AppCache` should end up looking like this::
+the ``PurgeListener`` so your ``AppCache`` should end up looking like this::
 
     use FOS\HttpCache\SymfonyCache\TaggableStore();
     use FOS\HttpCache\SymfonyCache\PurgeTagsListener();
@@ -330,7 +330,7 @@ the `PurgeListener` so your `AppCache` should end up looking like this::
         $this->addSubscriber(new PurgeTagsListener());
     }
 
-The `TaggableStore` can be configured by passing an array of `$options` as a
+The ``TaggableStore`` can be configured by passing an array of ``$options`` as a
 second argument:
 
 * **prune_threshold**: Configure the number of write actions until the

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -330,6 +330,32 @@ the `PurgeListener` so your `AppCache` should end up looking like this::
         $this->addSubscriber(new PurgeTagsListener());
     }
 
+The `TaggableStore` can be configured by passing an array of `$options` as a
+second argument:
+
+* **prune_threshold**: Configure the number of write actions until the
+  store will prune the expired cache entries. Pass 0 if you want to disable
+  automated pruning.
+  Type: int
+
+* **purge_tags_header**: The HTTP header name used to check for tags
+  Type: string
+
+* **cache**: The cache adapter.
+  Use this option if you want to use a different cache implementation than the
+  default one.
+  Note that there are very good reasons that the local adapters are used by
+  default. This is to protect you as a developer! Only override it if you're
+  really sure your cache implementation meets the needs of Symfony's HttpCache.
+  Type: TagAwareAdapterInterface
+
+* **lock_factory**: The lock factory.
+  Use this option if you want to use a different lock implementation than the
+  default one.
+  Note that there are very good reasons that the local adapters are used by
+  default. This is to protect you as a developer! Only override it if you're
+  really sure your lock implementation meets the needs of Symfony's HttpCache.
+  Type: Factory
 
 Cleaning the Cookie Header
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -30,6 +30,8 @@ Using the trait
 Your ``AppCache`` needs to implement ``CacheInvalidation`` and use the
 trait ``FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache``::
 
+    // app/AppCache.php
+
     use FOS\HttpCache\SymfonyCache\CacheInvalidation;
     use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
     use Symfony\Component\HttpFoundation\Request;

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -180,6 +180,115 @@ You can configure the listener just the same as the `PurgeListener` plus the
 
   **default**: ``X-Cache-Tags``
 
+If you want support for tag based cache invalidation, you need to register both,
+the ``PurgeListener`` and the ``TaggableStore`` so your ``AppCache`` should end
+up looking like this::
+
+    use FOS\HttpCache\SymfonyCache\TaggableStore();
+    use FOS\HttpCache\SymfonyCache\PurgeTagsListener();
+
+    // ...
+
+    /**
+     * Overwrite constructor to register the TaggableStore.
+     */
+    public function __construct(
+        HttpKernelInterface $kernel,
+        SurrogateInterface $surrogate = null,
+        array $options = []
+    ) {
+        $store = new TaggableStore($kernel->getCacheDir());
+
+        parent::__construct($kernel, $store, $surrogate, $options);
+
+        $this->addSubscriber(new PurgeTagsListener());
+    }
+
+
+.. _taggablestore:
+
+The TaggableStore
+^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.1
+
+    The ``TaggableStore`` has been added in version 2.1.
+
+.. warning::
+
+    You need at least versions 3.4 of ``symfony/cache`` and ``symfony/lock``
+    to use this feature! Add the following lines to your ``composer.json`` and run
+    ``composer update``::
+
+        "symfony/lock": "^3.4",
+        "symfony/cache": "^3.4",
+
+
+Symfony's ``HttpCache`` does not support tags based cache invalidation by default.
+However, this library ships with a ``TaggableStore`` and a corresponding
+``PurgeTagsListener`` which provide this functionality.
+Even if you do not want to invalidate cache entries by tags, you might be
+interested in using the ``TaggableStore`` instead of the default ``Store``
+implementation Symfony ships with.
+
+That's because ``TaggableStore`` also prunes expired entries on a regular basis
+which is something the default ``Store`` does not. The default ``Store`` keeps
+filling up your file system without ever cleaning up expired cache entries.
+The ``TaggableStore`` counts all the cache write operations (so fetching items
+from the cache is not slowed down) and after reaching a configurable
+threshold (default ``500``), it prunes expired data. If you want to disable
+pruning, you can set the option ``prune_threshold`` to ``0``.
+This means that after every ``500`` HTTP cache writes, your file system directory
+will be cleaned up and thus kept in good shape.
+You can configure the prune threshold by providing a different threshold as
+second argument to the constructor of ``TaggableStore``.
+
+For this to work, you have to use the ``TaggableStore`` in your kernel::
+
+    use FOS\HttpCache\SymfonyCache\PurgeTagsListener();
+
+    // ...
+
+    /**
+     * Overwrite constructor to register the TaggableStore.
+     */
+    public function __construct(
+        HttpKernelInterface $kernel,
+        SurrogateInterface $surrogate = null,
+        array $options = []
+    ) {
+        $store = new TaggableStore($kernel->getCacheDir());
+
+        parent::__construct($kernel, $store, $surrogate, $options);
+    }
+
+The ``TaggableStore`` can be configured by passing an array of ``$options`` as a
+second argument:
+
+* **prune_threshold**: Configure the number of write actions until the
+  store will prune the expired cache entries. Pass 0 if you want to disable
+  automated pruning.
+  Type: int
+
+* **purge_tags_header**: The HTTP header name used to check for tags
+  Type: string
+
+* **cache**: The cache adapter.
+  Use this option if you want to use a different cache implementation than the
+  default one.
+  Note that there are very good reasons that the local adapters are used by
+  default. This is to protect you as a developer! Only override it if you're
+  really sure your cache implementation meets the needs of Symfony's HttpCache.
+  Type: Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
+
+* **lock_factory**: The lock factory.
+  Use this option if you want to use a different lock implementation than the
+  default one.
+  Note that there are very good reasons that the local adapters are used by
+  default. This is to protect you as a developer! Only override it if you're
+  really sure your lock implementation meets the needs of Symfony's HttpCache.
+  Type: Symfony\Component\Lock\Factory
+
 Refresh
 ~~~~~~~
 
@@ -266,96 +375,6 @@ options through the constructor:
 
         RewriteEngine On
         RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-
-
-.. _taggablestore:
-
-The TaggableStore
-^^^^^^^^^^^^^^^^^
-
-.. versionadded:: 2.1
-
-    The ``TaggableStore`` has been added in version 2.1.
-
-.. warning::
-
-    You need at least versions 3.4 of ``symfony/cache`` and ``symfony/lock``
-    to use this feature! Add the following lines to your ``composer.json`` and run
-    ``composer update``::
-
-        "symfony/lock": "^3.4",
-        "symfony/cache": "^3.4",
-
-
-Symfony's ``HttpCache`` does not support tags based cache invalidation by default.
-However, this library ships with a ``TaggableStore`` and a corresponding
-``PurgeTagsListener`` which provide this functionality.
-Even if you do not want to invalidate cache entries by tags, you might be
-interested in using the ``TaggableStore`` instead of the default ``Store``
-implementation Symfony ships with.
-
-That's because ``TaggableStore`` also prunes expired entries on a regular basis
-which is something the default ``Store`` does not. The default ``Store`` keeps
-filling up your file system without ever cleaning up expired cache entries.
-The ``TaggableStore`` counts all the cache write operations (so fetching items
-from the cache is not slowed down) and after reaching a configurable
-threshold (default ``500``), it prunes expired data. If you want to disable
-pruning, you can set the option ``prune_threshold`` to ``0``.
-This means that after every ``500`` HTTP cache writes, your file system directory
-will be cleaned up and thus kept in good shape.
-You can configure the prune threshold by providing a different threshold as
-second argument to the constructor of ``TaggableStore``.
-
-For this to work, you have to use the ``TaggableStore`` in your kernel.
-If you want support for tag based cache invalidation, you also need to register
-the ``PurgeListener`` so your ``AppCache`` should end up looking like this::
-
-    use FOS\HttpCache\SymfonyCache\TaggableStore();
-    use FOS\HttpCache\SymfonyCache\PurgeTagsListener();
-
-    // ...
-
-    /**
-     * Overwrite constructor to register the TaggableStore.
-     */
-    public function __construct(
-        HttpKernelInterface $kernel,
-        SurrogateInterface $surrogate = null,
-        array $options = []
-    ) {
-        $store = new TaggableStore($kernel->getCacheDir());
-
-        parent::__construct($kernel, $store, $surrogate, $options);
-
-        $this->addSubscriber(new PurgeTagsListener());
-    }
-
-The ``TaggableStore`` can be configured by passing an array of ``$options`` as a
-second argument:
-
-* **prune_threshold**: Configure the number of write actions until the
-  store will prune the expired cache entries. Pass 0 if you want to disable
-  automated pruning.
-  Type: int
-
-* **purge_tags_header**: The HTTP header name used to check for tags
-  Type: string
-
-* **cache**: The cache adapter.
-  Use this option if you want to use a different cache implementation than the
-  default one.
-  Note that there are very good reasons that the local adapters are used by
-  default. This is to protect you as a developer! Only override it if you're
-  really sure your cache implementation meets the needs of Symfony's HttpCache.
-  Type: TagAwareAdapterInterface
-
-* **lock_factory**: The lock factory.
-  Use this option if you want to use a different lock implementation than the
-  default one.
-  Note that there are very good reasons that the local adapters are used by
-  default. This is to protect you as a developer! Only override it if you're
-  really sure your lock implementation meets the needs of Symfony's HttpCache.
-  Type: Factory
 
 Cleaning the Cookie Header
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -299,7 +299,8 @@ which is something the default `Store` does not. The default `Store` keeps
 filling up your file system without ever cleaning up expired cache entries.
 The `TaggableStore` counts all the cache write operations (so fetching items
 from the cache is not slowed down) and after reaching a configurable
-threshold (default `500`), it prunes expired data.
+threshold (default `500`), it prunes expired data. If you want to disable
+pruning, you can set the threshold to `0`.
 This means that after every `500` HTTP cache writes, your file system directory
 will be cleaned up and thus kept in good shape.
 You can configure the prune threshold by providing a different threshold as

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -152,15 +152,14 @@ Purge tags (cache invalidation using tags)
 
 .. warning::
 
-    You need at least Symfony 3.4 (the lock component to be precise) to use
-    this feature!
+    You need at least Symfony 3.4 to use this feature!
 
 
-Symfony's `HttpCache` does not support cache invalidation by tags by default.
-However, this library ships with a `TaggableStore` and a `PurgeTagsListener`
-which provide exactly that.
+Symfony's `HttpCache` does not support tags based cache invalidation by default.
+However, this library ships with a `TaggableStore` and a corresponding
+`PurgeTagsListener` which provide this functionality.
 
-Purging tags is only allowed from the same machine by default too.
+Purging tags is only allowed from the same machine by default.
 You can configure the listener just the same as the `PurgeListener` plus the
 `purge_tags_method` and `purge_tags_header`:
 
@@ -204,6 +203,21 @@ so your `AppCache` should end up looking like this::
 
         $this->addSubscriber(new PurgeTagsListener());
     }
+
+.. note::
+
+    Even if you do not need tags based cache invalidation, you might still be
+    interested in choosing the `TaggableStore` over the default `Store` that
+    Symfony ships with. That's because `TaggableStore` also prunes expired
+    entries on a regular basis which is something the default `Store` does not.
+    The default `Store` keeps filling up your file system without ever cleaning
+    up expired cache entries. The `TaggableStore` counts all the cache write
+    operations (so fetching items from the cache is not slowed down) and after
+    reaching a configurable threshold (default `500`), it prunes expired data.
+    This means that after every `500` HTTP cache writes, your file system directory
+    will be cleaned up and thus kept in good shape.
+    You can configure the prune threshold by providing a different threshold as
+    second argument to the constructor of `TaggableStore`.
 
 Refresh
 ~~~~~~~

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -150,9 +150,15 @@ one of ``client_ips`` or ``client_matcher``*.
 Purge tags (cache invalidation using tags)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    You need at least Symfony 3.4 (the lock component to be precise) to use
+    this feature!
+
+
 Symfony's `HttpCache` does not support cache invalidation by tags by default.
 However, this library ships with a `TaggableStore` and a `PurgeTagsListener`
-provide exactly that.
+which provide exactly that.
 
 Purging tags is only allowed from the same machine by default too.
 You can configure the listener just the same as the `PurgeListener` plus the
@@ -198,8 +204,6 @@ so your `AppCache` should end up looking like this::
 
         $this->addSubscriber(new PurgeTagsListener());
     }
-
-
 
 Refresh
 ~~~~~~~

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -129,6 +129,29 @@ other hosts, provide the IPs of the machines allowed to purge, or provide a
 RequestMatcher that checks for an Authorization header or similar. *Only set
 one of ``client_ips`` or ``client_matcher``*.
 
+Symfony's `HttpCache` does not support cache invalidation by tags by default.
+However, this library ships with a `TaggableStore` that provides exactly that.
+If you want to use this, adjust your `AppCache` as follows::
+
+    use FOS\HttpCache\SymfonyCache\TaggableStore();
+
+    // ...
+
+    /**
+     * Overwrite constructor to register the TaggableStore.
+     */
+    public function __construct(
+        HttpKernelInterface $kernel,
+        StoreInterface $store,
+        SurrogateInterface $surrogate = null,
+        array $options = []
+    ) {
+        $store = new TaggableStore($kernel->getCacheDir());
+
+        parent::__construct($kernel, $store, $surrogate, $options);
+    }
+
+
 * **client_ips**: String with IP or array of IPs that are allowed to
   purge the cache.
 
@@ -140,6 +163,8 @@ one of ``client_ips`` or ``client_matcher``*.
   **default**: ``null``
 
 * **purge_method**: HTTP Method used with purge requests.
+
+* **purge_tags_header**: HTTP Header used for purging tags. (must match the 2nd argument of `TaggableStore`)
 
   **default**: ``PURGE``
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -150,9 +150,18 @@ one of ``client_ips`` or ``client_matcher``*.
 Purge tags (cache invalidation using tags)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 2.1
+
+    The `TaggableStore` has been added in version 2.1.
+
 .. warning::
 
-    You need at least Symfony 3.4 to use this feature!
+    You need at least versions 3.4 of `symfony/cache` and `symfony/lock`
+    to use this feature! Add the following lines to your `composer.json` and run
+    `composer update`::
+
+    "symfony/lock": "^3.4",
+    "symfony/cache": "^3.4",
 
 
 Symfony's `HttpCache` does not support tags based cache invalidation by default.

--- a/src/ProxyClient/HttpProxyClient.php
+++ b/src/ProxyClient/HttpProxyClient.php
@@ -129,7 +129,6 @@ abstract class HttpProxyClient implements ProxyClient
     protected function splitLongHeaderValue($value, $length = 7500, $delimiter = ',')
     {
         if (mb_strlen($value) <= $length) {
-
             return [$value];
         }
 
@@ -139,15 +138,13 @@ abstract class HttpProxyClient implements ProxyClient
         $index = 0;
 
         foreach ($chunks as $chunk) {
-
             $chunkLength = mb_strlen($chunk) + 1;
 
             if (($currentLength + $chunkLength) <= $length) {
-
                 $tmp[$index][] = $chunk;
                 $currentLength += $chunkLength;
             } else {
-                $index++;
+                ++$index;
                 $currentLength = $chunkLength;
                 $tmp[$index][] = $chunk;
             }

--- a/src/ProxyClient/HttpProxyClient.php
+++ b/src/ProxyClient/HttpProxyClient.php
@@ -114,4 +114,50 @@ abstract class HttpProxyClient implements ProxyClient
 
         return $tags;
     }
+
+    /**
+     * Splits a header value into an array of values. E.g. useful for tag
+     * invalidation requests where you might need multiple requests if you
+     * want to invalidate too many cache tags (so the header would get too long).
+     *
+     * @param string $value
+     * @param int    $length
+     * @param string $delimiter
+     *
+     * @return array
+     */
+    protected function splitLongHeaderValue($value, $length = 7500, $delimiter = ',')
+    {
+        if (mb_strlen($value) <= $length) {
+
+            return [$value];
+        }
+
+        $tmp = [];
+        $chunks = explode($delimiter, $value);
+        $currentLength = 0;
+        $index = 0;
+
+        foreach ($chunks as $chunk) {
+
+            $chunkLength = mb_strlen($chunk) + 1;
+
+            if (($currentLength + $chunkLength) <= $length) {
+
+                $tmp[$index][] = $chunk;
+                $currentLength += $chunkLength;
+            } else {
+                $index++;
+                $currentLength = $chunkLength;
+                $tmp[$index][] = $chunk;
+            }
+        }
+
+        $result = [];
+        foreach ($tmp as $values) {
+            $result[] = implode($delimiter, $values);
+        }
+
+        return $result;
+    }
 }

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 
 /**
@@ -24,7 +25,7 @@ use FOS\HttpCache\SymfonyCache\PurgeListener;
  * @author David de Boer <david@driebit.nl>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
+class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, TagCapable
 {
     const HTTP_METHOD_REFRESH = 'GET';
 
@@ -54,7 +55,24 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
         $resolver = parent::configureOptions();
         $resolver->setDefault('purge_method', PurgeListener::DEFAULT_PURGE_METHOD);
         $resolver->setAllowedTypes('purge_method', 'string');
+        $resolver->setDefault('purge_tags_header', PurgeListener::DEFAULT_PURGE_TAGS_HEADER);
+        $resolver->setAllowedTypes('purge_tags_header', 'string');
 
         return $resolver;
+    }
+
+    /**
+     * Remove/Expire cache objects based on cache tags.
+     *
+     * @param array $tags Tags that should be removed/expired from the cache
+     *
+     * @return $this
+     */
+    public function invalidateTags(array $tags)
+    {
+        // TODO: how should we escape best here?
+        $escapedTags = $tags;
+
+        $this->purge('/', [$this->options['purge_tags_header'] => implode(',' , $escapedTags)]);
     }
 }

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -52,9 +52,8 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
     protected function configureOptions()
     {
         $resolver = parent::configureOptions();
-        $resolver->setDefaults([
-            'purge_method' => PurgeListener::DEFAULT_PURGE_METHOD,
-        ]);
+        $resolver->setDefault('purge_method', PurgeListener::DEFAULT_PURGE_METHOD);
+        $resolver->setAllowedTypes('purge_method', 'string');
 
         return $resolver;
     }

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -70,8 +70,7 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
      */
     public function invalidateTags(array $tags)
     {
-        // TODO: how should we escape best here?
-        $escapedTags = $tags;
+        $escapedTags = $this->escapeTags($tags);
 
         $this->purge('/', [$this->options['purge_tags_header'] => implode(',', $escapedTags)]);
     }

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -15,6 +15,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 
 /**
  * Symfony HttpCache invalidator.
@@ -55,7 +56,7 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
         $resolver = parent::configureOptions();
         $resolver->setDefault('purge_method', PurgeListener::DEFAULT_PURGE_METHOD);
         $resolver->setAllowedTypes('purge_method', 'string');
-        $resolver->setDefault('purge_tags_header', PurgeListener::DEFAULT_PURGE_TAGS_HEADER);
+        $resolver->setDefault('purge_tags_header', PurgeTagsListener::DEFAULT_PURGE_TAGS_HEADER);
         $resolver->setAllowedTypes('purge_tags_header', 'string');
 
         return $resolver;

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -73,6 +73,6 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
         // TODO: how should we escape best here?
         $escapedTags = $tags;
 
-        $this->purge('/', [$this->options['purge_tags_header'] => implode(',' , $escapedTags)]);
+        $this->purge('/', [$this->options['purge_tags_header'] => implode(',', $escapedTags)]);
     }
 }

--- a/src/SymfonyCache/PurgeListener.php
+++ b/src/SymfonyCache/PurgeListener.php
@@ -98,7 +98,6 @@ class PurgeListener extends AccessControlledListener
         if ($request->headers->has($this->purgeTagsHeader)
             && $store instanceof TaggableStore
         ) {
-            // TODO: need to unescape again here
             $tags = explode(',', $request->headers->get($this->purgeTagsHeader));
 
             if ($store->invalidateTags($tags)) {

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -1,0 +1,387 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\SymfonyCache;
+
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
+use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\Store\FlockStore;
+
+/**
+ * Implements a storage for Symfony's HttpCache that supports tagging.
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class TaggableStore implements StoreInterface
+{
+    const NON_VARYING_KEY = 'non-varying';
+
+    /**
+     * @var string
+     */
+    private $purgeTagsHeader;
+
+    /**
+     * @var TagAwareAdapter
+     */
+    private $cache;
+
+    /**
+     * @var Factory
+     */
+    private $lockFactory;
+
+    /**
+     * @var LockInterface[]
+     */
+    private $locks = [];
+
+    /**
+     * @param string $cacheDir
+     */
+    public function __construct($cacheDir, $purgeTagsHeader = PurgeListener::DEFAULT_PURGE_TAGS_HEADER)
+    {
+        if (!class_exists(Factory::class)) {
+            throw new \RuntimeException('You need at least Symfony 3.4 to use the TaggableStore.');
+        }
+
+        $this->purgeTagsHeader = $purgeTagsHeader;
+        $this->cache = $cache = new TagAwareAdapter(new FilesystemAdapter('fos-http-cache', 0, $cacheDir));
+        $this->lockFactory = new Factory(new FlockStore($cacheDir));
+    }
+
+    /**
+     * @return TagAwareAdapter
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Locates a cached Response for the Request provided.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return Response|null A Response instance, or null if no cache entry was found
+     */
+    public function lookup(Request $request)
+    {
+        $cacheKey = $this->getCacheKey($request);
+
+        $item = $this->cache->getItem($cacheKey);
+
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        $entries = $item->get();
+
+        foreach ($entries as $varyKeyResponse => $responseData) {
+            // This can only happen if one entry only
+            if (self::NON_VARYING_KEY === $varyKeyResponse) {
+                return $this->restoreResponse($responseData);
+            }
+
+            // Otherwise we have to see if Vary headers match
+            $varyKeyRequest = $this->getVaryKey(
+                $responseData['vary'],
+                $request->headers
+            );
+
+            if ($varyKeyRequest === $varyKeyResponse) {
+                return $this->restoreResponse($responseData);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Writes a cache entry to the store for the given Request and Response.
+     *
+     * Existing entries are read and any that match the response are removed. This
+     * method calls write with the new list of cache entries.
+     *
+     * @param Request  $request  A Request instance
+     * @param Response $response A Response instance
+     *
+     * @return string The key under which the response is stored
+     */
+    public function write(Request $request, Response $response)
+    {
+        if (!$response->headers->has('X-Content-Digest')) {
+            $contentDigest = $this->generateContentDigest($response);
+
+            if (false === $this->save($contentDigest, $response->getContent())) {
+                throw new \RuntimeException('Unable to store the entity.');
+            }
+
+            $response->headers->set('X-Content-Digest', $contentDigest);
+
+            if (!$response->headers->has('Transfer-Encoding')) {
+                $response->headers->set('Content-Length', strlen($response->getContent()));
+            }
+        }
+
+        $cacheKey = $this->getCacheKey($request);
+        $headers = $response->headers->all();
+        unset($headers['age']);
+
+        $item = $this->cache->getItem($cacheKey);
+
+        if (!$item->isHit()) {
+            $entries = [];
+        } else {
+            $entries = $item->get();
+        }
+
+        // Add or replace entry with current Vary header key
+        $entries[$this->getVaryKey($response->getVary(), $response->headers)] = [
+            'vary' => $response->getVary(),
+            'headers' => $headers,
+            'status' => $response->getStatusCode(),
+        ];
+
+        // If the response has a Vary header we remove the non-varying entry
+        if ($response->hasVary()) {
+            unset($entries[self::NON_VARYING_KEY]);
+        }
+
+        // Support tagging
+        $tags = [];
+        if ($response->headers->has($this->purgeTagsHeader)) {
+            $tags = explode(',', $response->headers->get($this->purgeTagsHeader));
+        }
+
+        $this->save($cacheKey, $entries, $tags);
+
+        return $cacheKey;
+    }
+
+    /**
+     * Invalidates all cache entries that match the request.
+     *
+     * @param Request $request A Request instance
+     */
+    public function invalidate(Request $request)
+    {
+        $cacheKey = $this->getCacheKey($request);
+
+        $this->cache->deleteItem($cacheKey);
+    }
+
+    /**
+     * Locks the cache for a given Request.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return bool|string true if the lock is acquired, the path to the current lock otherwise
+     */
+    public function lock(Request $request)
+    {
+        $cacheKey = $this->getCacheKey($request);
+
+        if (isset($this->locks[$cacheKey])) {
+            return false;
+        }
+
+        $this->locks[$cacheKey] = $this->lockFactory
+            ->createLock($cacheKey);
+
+        return $this->locks[$cacheKey]->acquire();
+    }
+
+    /**
+     * Releases the lock for the given Request.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return bool False if the lock file does not exist or cannot be unlocked, true otherwise
+     */
+    public function unlock(Request $request)
+    {
+        $cacheKey = $this->getCacheKey($request);
+
+        if (!isset($this->locks[$cacheKey])) {
+            return false;
+        }
+
+        try {
+            $this->locks[$cacheKey]->release();
+        } catch (LockReleasingException $e) {
+            return false;
+        }
+
+        return true;    }
+
+    /**
+     * Returns whether or not a lock exists.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return bool true if lock exists, false otherwise
+     */
+    public function isLocked(Request $request)
+    {
+        $cacheKey = $this->getCacheKey($request);
+
+        if (!isset($this->locks[$cacheKey])) {
+            return false;
+        }
+
+        return $this->locks[$cacheKey]->isAcquired();
+    }
+
+    /**
+     * Purges data for the given URL.
+     *
+     * @param string $url A URL
+     *
+     * @return bool true if the URL exists and has been purged, false otherwise
+     */
+    public function purge($url)
+    {
+        $cacheKey = $this->getCacheKey(Request::create($url));
+
+        return $this->cache->deleteItem($cacheKey);
+    }
+
+    /**
+     * Cleanups storage.
+     */
+    public function cleanup()
+    {
+        /** @var LockInterface $lock */
+        foreach ($this->locks as $lock) {
+            $lock->release();
+        }
+
+        $this->locks = [];
+    }
+
+    /**
+     * Remove/Expire cache objects based on cache tags.
+     * Returns true on success and false otherwise.
+     *
+     * @param array $tags Tags that should be removed/expired from the cache
+     *
+     * @return bool
+     */
+    public function invalidateTags(array $tags)
+    {
+        try {
+            return $this->cache->invalidateTags($tags);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function getCacheKey(Request $request)
+    {
+        // Strip scheme to treat https and http the same
+        $uri = $request->getUri();
+        $uri = substr($uri, strlen($request->getScheme().'://'));
+
+        return 'md'.hash('sha256', $uri);
+    }
+
+    /**
+     *
+     * @param array     $vary
+     * @param HeaderBag $headerBag
+     *
+     * @return string
+     */
+    public function getVaryKey(array $vary, HeaderBag $headerBag)
+    {
+        if (0 === count($vary)) {
+            return self::NON_VARYING_KEY;
+        }
+
+        sort($vary);
+
+        $hashData = '';
+
+        foreach ($vary as $headerName) {
+            $hashData .= $headerName.':'.$headerBag->get($headerName);
+        }
+
+        return hash('sha256', $hashData);
+    }
+
+    /**
+     * @param Response $response
+     *
+     * @return string
+     */
+    public function generateContentDigest(Response $response)
+    {
+        return 'en'.hash('sha256', $response->getContent());
+    }
+
+    /**
+     * @param string $key
+     * @param string $data
+     * @param array $tags
+     *
+     * @return bool
+     */
+    private function save($key, $data, $tags = [])
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($data);
+
+        if (0 !== count($tags)) {
+            $item->tag($tags);
+        }
+
+        return $this->cache->save($item);
+    }
+
+    /**
+     * Restores a Response from the cached data.
+     *
+     * @param array $cacheData An array containing the cache data
+     *
+     * @return Response|null
+     */
+    private function restoreResponse(array $cacheData)
+    {
+        $body = null;
+
+        if (isset($cacheData['headers']['x-content-digest'][0])) {
+            $item = $this->cache->getItem($cacheData['headers']['x-content-digest'][0]);
+            if ($item->isHit()) {
+                $body = $item->get();
+            }
+        }
+
+        return new Response(
+            $body,
+            $cacheData['status'],
+            $cacheData['headers']
+        );
+    }
+}

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -233,6 +233,7 @@ class TaggableStore implements StoreInterface
 
         try {
             $this->locks[$cacheKey]->release();
+            unset($this->locks[$cacheKey]);
         } catch (LockReleasingException $e) {
             return false;
         }

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -225,9 +225,10 @@ class TaggableStore implements StoreInterface
 
         try {
             $this->locks[$cacheKey]->release();
-            unset($this->locks[$cacheKey]);
         } catch (LockReleasingException $e) {
             return false;
+        } finally {
+            unset($this->locks[$cacheKey]);
         }
 
         return true;

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -229,7 +229,8 @@ class TaggableStore implements StoreInterface
             return false;
         }
 
-        return true;    }
+        return true;
+    }
 
     /**
      * Returns whether or not a lock exists.
@@ -308,7 +309,6 @@ class TaggableStore implements StoreInterface
     }
 
     /**
-     *
      * @param array     $vary
      * @param HeaderBag $headerBag
      *
@@ -344,7 +344,7 @@ class TaggableStore implements StoreInterface
     /**
      * @param string $key
      * @param string $data
-     * @param array $tags
+     * @param array  $tags
      *
      * @return bool
      */

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -269,7 +269,7 @@ class TaggableStore implements StoreInterface
     /**
      * Release all locks.
      *
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function cleanup()
     {

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -75,14 +75,6 @@ class TaggableStore implements StoreInterface
     }
 
     /**
-     * @return TagAwareAdapter
-     */
-    public function getCache()
-    {
-        return $this->cache;
-    }
-
-    /**
      * Locates a cached Response for the Request provided.
      *
      * @param Request $request A Request instance

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -63,7 +63,7 @@ class TaggableStore implements StoreInterface
         }
 
         $this->purgeTagsHeader = $purgeTagsHeader;
-        $this->cache = $cache = new TagAwareAdapter(new FilesystemAdapter('fos-http-cache', 0, $cacheDir));
+        $this->cache = new TagAwareAdapter(new FilesystemAdapter('fos-http-cache', 0, $cacheDir));
 
         if (SemaphoreStore::isSupported(false)) {
             $store = new SemaphoreStore();

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -64,9 +64,9 @@ class TaggableStore implements StoreInterface
     /**
      * Constructor.
      *
-     * @param string $cacheDir          The cache directory.
-     * @param int    $pruneThreshold    The number of write operations until orphan data gets pruned (default: 500)
-     * @param string $purgeTagsHeader   The tags header name
+     * @param string $cacheDir        The cache directory
+     * @param int    $pruneThreshold  The number of write operations until orphan data gets pruned (default: 500)
+     * @param string $purgeTagsHeader The tags header name
      */
     public function __construct($cacheDir, $pruneThreshold = 500, $purgeTagsHeader = PurgeTagsListener::DEFAULT_PURGE_TAGS_HEADER)
     {

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -56,7 +56,7 @@ class TaggableStore implements StoreInterface
     /**
      * @param string $cacheDir
      */
-    public function __construct($cacheDir, $purgeTagsHeader = PurgeListener::DEFAULT_PURGE_TAGS_HEADER)
+    public function __construct($cacheDir, $purgeTagsHeader = PurgeTagsListener::DEFAULT_PURGE_TAGS_HEADER)
     {
         if (!class_exists(Factory::class)) {
             throw new \RuntimeException('You need at least Symfony 3.4 to use the TaggableStore.');

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -472,6 +472,7 @@ class TaggableStore implements StoreInterface
     {
         if (!interface_exists(PruneableInterface::class)
             || !$this->cache instanceof PruneableInterface
+            || 0 === $this->pruneThreshold
         ) {
             return;
         }

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -328,7 +328,6 @@ class TaggableStore implements StoreInterface
     public function cleanup()
     {
         try {
-            /** @var LockInterface $lock */
             foreach ($this->locks as $lock) {
                 $lock->release();
             }

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -434,11 +434,9 @@ class TaggableStore implements StoreInterface
     private function getBestLocalLockStore($cacheDir)
     {
         if (SemaphoreStore::isSupported(false)) {
-            $store = new SemaphoreStore();
+            return new SemaphoreStore();
         } else {
-            $store = new FlockStore($cacheDir);
+            return new FlockStore($cacheDir);
         }
-
-        return $store;
     }
 }

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -22,6 +22,7 @@ use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Lock\Store\SemaphoreStore;
 
 /**
  * Implements a storage for Symfony's HttpCache that supports tagging.
@@ -63,7 +64,14 @@ class TaggableStore implements StoreInterface
 
         $this->purgeTagsHeader = $purgeTagsHeader;
         $this->cache = $cache = new TagAwareAdapter(new FilesystemAdapter('fos-http-cache', 0, $cacheDir));
-        $this->lockFactory = new Factory(new FlockStore($cacheDir));
+
+        if (SemaphoreStore::isSupported(false)) {
+            $store = new SemaphoreStore();
+        } else {
+            $store = new FlockStore($cacheDir);
+        }
+
+        $this->lockFactory = new Factory($store);
     }
 
     /**

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -278,12 +278,16 @@ class TaggableStore implements StoreInterface
      */
     public function cleanup()
     {
-        /** @var LockInterface $lock */
-        foreach ($this->locks as $lock) {
-            $lock->release();
+        try {
+            /** @var LockInterface $lock */
+            foreach ($this->locks as $lock) {
+                $lock->release();
+            }
+        } catch (LockReleasingException $e) {
+            // noop
+        } finally {
+            $this->locks = [];
         }
-
-        $this->locks = [];
     }
 
     /**

--- a/src/SymfonyCache/TaggableStore.php
+++ b/src/SymfonyCache/TaggableStore.php
@@ -267,7 +267,9 @@ class TaggableStore implements StoreInterface
     }
 
     /**
-     * Cleanups storage.
+     * Release all locks.
+     *
+     * {@inheritDoc}
      */
     public function cleanup()
     {

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -52,7 +52,6 @@ class SymfonyTest extends TestCase
         $symfony->purge('/url', ['X-Foo' => 'bar']);
     }
 
-
     public function testInvalidateTags()
     {
         $symfony = new Symfony($this->httpDispatcher);

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -87,7 +87,7 @@ class SymfonyTest extends TestCase
 
                         return true;
                     }),
-                    true
+                    true,
                 ],
                 [
                     $this->callback(function (RequestInterface $request) {
@@ -96,7 +96,7 @@ class SymfonyTest extends TestCase
 
                         return true;
                     }),
-                    true
+                    true,
                 ],
                 [
                     $this->callback(function (RequestInterface $request) {
@@ -105,7 +105,7 @@ class SymfonyTest extends TestCase
 
                         return true;
                     }),
-                    true
+                    true,
                 ]
             );
 

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -59,7 +59,7 @@ class SymfonyTest extends TestCase
         $this->httpDispatcher->shouldReceive('invalidate')->once()->with(
             \Mockery::on(
                 function (RequestInterface $request) {
-                    $this->assertEquals('PURGE', $request->getMethod());
+                    $this->assertEquals('PURGETAGS', $request->getMethod());
 
                     $this->assertEquals('/', $request->getUri());
                     $this->assertContains('foobar,other tag', $request->getHeaderLine('X-Cache-Tags'));
@@ -71,6 +71,73 @@ class SymfonyTest extends TestCase
         );
 
         $symfony->invalidateTags(['foobar', 'other tag']);
+    }
+
+    public function testInvalidateTagsWithALotOfTags()
+    {
+        $dispatcher = $this->createMock(HttpDispatcher::class);
+        $dispatcher
+            ->expects($this->exactly(3))
+            ->method('invalidate')
+            ->withConsecutive(
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertContains('foobar,foobar1,foobar2,foobar3,foobar4,foobar5,foobar6,foobar7,foobar8,foobar9,foobar10,foobar11', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true
+                ],
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertContains('foobar12,foobar13,foobar14,foobar15,foobar16,foobar17,foobar18,foobar19,foobar20,foobar22,foobar23', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true
+                ],
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertContains('foobar24,foobar25', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true
+                ]
+            );
+
+        $symfony = new Symfony($dispatcher, ['purge_tags_header_length' => 100]);
+
+        $symfony->invalidateTags([
+            'foobar',
+            'foobar1',
+            'foobar2',
+            'foobar3',
+            'foobar4',
+            'foobar5',
+            'foobar6',
+            'foobar7',
+            'foobar8',
+            'foobar9',
+            'foobar10',
+            'foobar11',
+            'foobar12',
+            'foobar13',
+            'foobar14',
+            'foobar15',
+            'foobar16',
+            'foobar17',
+            'foobar18',
+            'foobar19',
+            'foobar20',
+            'foobar22',
+            'foobar23',
+            'foobar24',
+            'foobar25',
+        ]);
     }
 
     public function testRefresh()

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -52,6 +52,28 @@ class SymfonyTest extends TestCase
         $symfony->purge('/url', ['X-Foo' => 'bar']);
     }
 
+
+    public function testInvalidateTags()
+    {
+        $symfony = new Symfony($this->httpDispatcher);
+
+        $this->httpDispatcher->shouldReceive('invalidate')->once()->with(
+            \Mockery::on(
+                function (RequestInterface $request) {
+                    $this->assertEquals('PURGE', $request->getMethod());
+
+                    $this->assertEquals('/', $request->getUri());
+                    $this->assertContains('foobar,other tag', $request->getHeaderLine('X-Cache-Tags'));
+
+                    return true;
+                }
+            ),
+            true
+        );
+
+        $symfony->invalidateTags(['foobar', 'other tag']);
+    }
+
     public function testRefresh()
     {
         $symfony = new Symfony($this->httpDispatcher);

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -14,7 +14,6 @@ namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
-use FOS\HttpCache\SymfonyCache\TaggableStore;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/SymfonyCache/PurgeListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeListenerTest.php
@@ -63,7 +63,6 @@ class PurgeListenerTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
-
     public function testPurgeWithTagsAllowed()
     {
         /** @var TaggableStore $store */

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -17,7 +17,6 @@ use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -366,8 +365,7 @@ class TaggableStoreTest extends TestCase
         $store->setCache($cache);
 
         foreach (range(1, 21) as $entry) {
-
-            $request = Request::create('https://foobar.com/' . $entry);
+            $request = Request::create('https://foobar.com/'.$entry);
             $response = new Response('hello world', 200);
 
             $store->write($request, $response);

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -94,6 +94,15 @@ class TaggableStoreTest extends TestCase
         $this->assertFalse($this->store->isLocked($request), 'Request is no longer locked.');
     }
 
+    public function testSameLockCanBeAquiredAgain()
+    {
+        $request = Request::create('/');
+
+        $this->assertTrue($this->store->lock($request));
+        $this->assertTrue($this->store->unlock($request));
+        $this->assertTrue($this->store->lock($request));
+    }
+
     public function testWriteStoresTheResponseContent()
     {
         $request = Request::create('/');

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -1,0 +1,340 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\TaggableStore;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TaggableStoreTest extends TestCase
+{
+    /**
+     * @var TaggableStore
+     */
+    private $store;
+
+    protected function setUp()
+    {
+        $this->store = new TaggableStore(sys_get_temp_dir());
+    }
+
+    protected function tearDown()
+    {
+        $this->store->getCache()->clear();
+        $this->store->cleanup();
+    }
+
+    public function testItLocksTheRequest()
+    {
+        $request = Request::create('/');
+        $result = $this->store->lock($request);
+
+        $this->assertTrue($result, 'It returns true if lock is acquired.');
+        $this->assertTrue($this->store->isLocked($request), 'Request is locked.');
+    }
+
+    public function testLockReturnsFalseIfTheLockWasAlreadyAcquired()
+    {
+        $request = Request::create('/');
+        $this->store->lock($request);
+
+        $result = $this->store->lock($request);
+
+        $this->assertFalse($result, 'It returns false if lock could not be acquired.');
+        $this->assertTrue($this->store->isLocked($request), 'Request is locked.');
+    }
+
+    public function testIsLockedReturnsFalseIfRequestIsNotLocked()
+    {
+        $request = Request::create('/');
+        $this->assertFalse($this->store->isLocked($request), 'Request is not locked.');
+    }
+
+    public function testIsLockedReturnsTrueIfLockWasAcquired()
+    {
+        $request = Request::create('/');
+        $this->store->lock($request);
+
+        $this->assertTrue($this->store->isLocked($request), 'Request is locked.');
+    }
+
+    public function testUnlockReturnsFalseIfLockWasNotAquired()
+    {
+        $request = Request::create('/');
+        $this->assertFalse($this->store->unlock($request), 'Request is not locked.');
+    }
+
+    public function testUnlockReturnsTrueIfLockIsReleased()
+    {
+        $request = Request::create('/');
+        $this->store->lock($request);
+
+        $this->assertTrue($this->store->unlock($request), 'Request was unlocked.');
+        $this->assertFalse($this->store->isLocked($request), 'Request is not locked.');
+    }
+
+    public function testLocksAreReleasedOnCleanup()
+    {
+        $request = Request::create('/');
+        $this->store->lock($request);
+
+        $this->store->cleanup();
+
+        $this->assertFalse($this->store->isLocked($request), 'Request is no longer locked.');
+    }
+
+    public function testWriteStoresTheResponseContent()
+    {
+        $request = Request::create('/');
+        $response = new Response('hello world', 200);
+
+        $contentDigest = $this->store->generateContentDigest($response);
+
+        $this->store->write($request, $response);
+
+        $this->assertTrue($this->store->getCache()->hasItem($contentDigest), 'Response content is stored in cache.');
+        $this->assertSame($response->getContent(), $this->store->getCache()->getItem($contentDigest)->get(), 'Response content is stored in cache.');
+        $this->assertSame($contentDigest, $response->headers->get('X-Content-Digest'), 'Content digest is stored in the response header.');
+        $this->assertSame(strlen($response->getContent()), $response->headers->get('Content-Length'), 'Response content length is updated.');
+    }
+
+    public function testWriteDoesNotStoreTheResponseContentOfNonOriginalResponse()
+    {
+        $request = Request::create('/');
+        $response = new Response('hello world', 200);
+
+        $contentDigest = $this->store->generateContentDigest($response);
+
+        $response->headers->set('X-Content-Digest', $contentDigest);
+
+        $this->store->write($request, $response);
+
+        $this->assertFalse($this->store->getCache()->hasItem($contentDigest), 'Response content is not stored in cache.');
+        $this->assertFalse($response->headers->has('Content-Length'), 'Response content length is not updated.');
+    }
+
+    public function testWriteOnlyUpdatesContentLengthIfThereIsNoTransferEncodingHeader()
+    {
+        $request = Request::create('/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('Transfer-Encoding', 'chunked');
+
+        $this->store->write($request, $response);
+
+        $this->assertFalse($response->headers->has('Content-Length'), 'Response content length is not updated.');
+    }
+
+    public function testWriteStoresEntries()
+    {
+        $request = Request::create('/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('age', 120);
+
+        $cacheKey = $this->store->getCacheKey($request);
+
+        $this->store->write($request, $response);
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+
+        $this->assertInstanceOf(CacheItemInterface::class, $cacheItem, 'Metadata is stored in cache.');
+        $this->assertTrue($cacheItem->isHit(), 'Metadata is stored in cache.');
+
+        $entries = $cacheItem->get();
+
+        $this->assertInternalType('array', $entries, 'Entries are stored in cache.');
+        $this->assertCount(1, $entries, 'One entry is stored.');
+        $this->assertSame($entries[TaggableStore::NON_VARYING_KEY]['headers'], array_diff_key($response->headers->all(), ['age' => []]), 'Response headers are stored with no age header.');
+    }
+
+    public function testWriteAddsTags()
+    {
+        $request = Request::create('/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('X-Cache-Tags', 'foobar,other tag');
+
+        $cacheKey = $this->store->getCacheKey($request);
+
+        $this->store->write($request, $response);
+
+        $this->assertTrue($this->store->getCache()->getItem($cacheKey)->isHit());
+        $this->assertTrue($this->store->invalidateTags(['foobar']));
+        $this->assertFalse($this->store->getCache()->getItem($cacheKey)->isHit());
+
+    }
+
+    public function testVaryResponseDropsNonVaryingOne()
+    {
+        $request = Request::create('/');
+        $nonVarying = new Response('hello world', 200);
+        $varying = new Response('hello world', 200, ['Vary' => 'Foobar', 'Foobar' => 'whatever']);
+
+        $this->store->write($request, $nonVarying);
+
+        $cacheKey = $this->store->getCacheKey($request);
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+        $entries = $cacheItem->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertSame(TaggableStore::NON_VARYING_KEY, key($entries));
+
+        $this->store->write($request, $varying);
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+
+        $entries = $cacheItem->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertNotSame(TaggableStore::NON_VARYING_KEY, key($entries));
+    }
+
+    public function testRegularCacheKey()
+    {
+        $request = Request::create('https://foobar.com/');
+        $expected = 'md'.hash('sha256', 'foobar.com/');
+        $this->assertSame($expected, $this->store->getCacheKey($request));
+    }
+
+    public function testHttpAndHttpsGenerateTheSameCacheKey()
+    {
+        $request = Request::create('https://foobar.com/');
+        $cacheKeyHttps = $this->store->getCacheKey($request);
+        $request = Request::create('http://foobar.com/');
+        $cacheKeyHttp = $this->store->getCacheKey($request);
+
+        $this->assertSame($cacheKeyHttps, $cacheKeyHttp);
+    }
+
+    public function testRegularLookup()
+    {
+        $request = Request::create('https://foobar.com/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('Foobar', 'whatever');
+
+        $this->store->write($request, $response);
+
+        $result = $this->store->lookup($request);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame('hello world', $result->getContent());
+        $this->assertSame('whatever', $result->headers->get('Foobar'));
+    }
+
+    public function testLookupWithEmptyCache()
+    {
+        $request = Request::create('https://foobar.com/');
+
+        $result = $this->store->lookup($request);
+
+        $this->assertNull($result);
+    }
+
+    public function testLookupWithVaryResponse()
+    {
+        $request = Request::create('https://foobar.com/');
+        $response = new Response('hello world', 200, ['Vary' => 'Foobar', 'Foobar' => 'whatever']);
+
+        $this->store->write($request, $response);
+
+        $result = $this->store->lookup($request);
+
+        $this->assertNull($result);
+
+        $request = Request::create('https://foobar.com/');
+        $request->headers->set('Foobar', 'whatever');
+
+        $result = $this->store->lookup($request);
+
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame('hello world', $result->getContent());
+        $this->assertSame('Foobar', $result->headers->get('Vary'));
+        $this->assertSame('whatever', $result->headers->get('Foobar'));
+    }
+
+    public function testLookupWithMultipleVaryResponse()
+    {
+        $request = Request::create('https://foobar.com/');
+        $response1 = new Response('should be whatever 1', 200, ['Vary' => 'Foobar', 'Foobar' => 'whatever1']);
+        $response2 = new Response('should be whatever 2', 200, ['Vary' => 'Foobar', 'Foobar' => 'whatever2']);
+
+        // Fill cache
+        $this->store->write($request, $response1);
+        $this->store->write($request, $response2);
+
+        // Should return null because no header provided
+        $request = Request::create('https://foobar.com/');
+        $result = $this->store->lookup($request);
+        $this->assertNull($result);
+
+        // Should return null because header provided but non matching content
+        $request = Request::create('https://foobar.com/');
+        $request->headers->set('Foobar', 'whatever3');
+        $result = $this->store->lookup($request);
+        $this->assertNull($result);
+
+        // Should return $response1
+        $request = Request::create('https://foobar.com/');
+        $request->headers->set('Foobar', 'whatever1');
+        $result = $this->store->lookup($request);
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame('should be whatever 1', $result->getContent());
+        $this->assertSame('Foobar', $result->headers->get('Vary'));
+        $this->assertSame('whatever1', $result->headers->get('Foobar'));
+
+        // Should return $response2
+        $request = Request::create('https://foobar.com/');
+        $request->headers->set('Foobar', 'whatever2');
+        $result = $this->store->lookup($request);
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame('should be whatever 2', $result->getContent());
+        $this->assertSame('Foobar', $result->headers->get('Vary'));
+        $this->assertSame('whatever2', $result->headers->get('Foobar'));
+    }
+
+    public function testInvalidate()
+    {
+        $request = Request::create('https://foobar.com/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('Foobar', 'whatever');
+
+        $this->store->write($request, $response);
+        $cacheKey = $this->store->getCacheKey($request);
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+        $this->assertTrue($cacheItem->isHit());
+
+        $this->store->invalidate($request);
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+        $this->assertFalse($cacheItem->isHit());
+    }
+
+    public function testPurge()
+    {
+        $request = Request::create('https://foobar.com/');
+        $response = new Response('hello world', 200);
+        $response->headers->set('Foobar', 'whatever');
+
+        $this->store->write($request, $response);
+        $cacheKey = $this->store->getCacheKey($request);
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+        $this->assertTrue($cacheItem->isHit());
+
+        $this->store->purge('https://foobar.com/');
+
+        $cacheItem = $this->store->getCache()->getItem($cacheKey);
+        $this->assertFalse($cacheItem->isHit());
+    }
+}

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -119,8 +119,7 @@ class TaggableStoreTest extends TestCase
             ->method('saveDeferred')
             ->willReturn(false);
 
-        $store = new TaggableStore(sys_get_temp_dir());
-        $store->setCache($cache);
+        $store = new TaggableStore(sys_get_temp_dir(), ['cache' => $cache]);
 
         $request = Request::create('/');
         $response = new Response('hello world', 200);
@@ -221,8 +220,7 @@ class TaggableStoreTest extends TestCase
             ->method('invalidateTags')
             ->willThrowException(new \Symfony\Component\Cache\Exception\InvalidArgumentException());
 
-        $store = new TaggableStore(sys_get_temp_dir());
-        $store->setCache($cache);
+        $store = new TaggableStore(sys_get_temp_dir(), ['cache' => $cache]);
 
         $this->assertFalse($store->invalidateTags(['foobar']));
     }
@@ -404,8 +402,10 @@ class TaggableStoreTest extends TestCase
             ->expects($this->exactly(3))
             ->method('prune');
 
-        $store = new TaggableStore(sys_get_temp_dir(), 5);
-        $store->setCache($cache);
+        $store = new TaggableStore(sys_get_temp_dir(), [
+            'cache' => $cache,
+            'prune_threshold' => 5,
+        ]);
 
         foreach (range(1, 21) as $entry) {
             $request = Request::create('https://foobar.com/'.$entry);
@@ -429,8 +429,10 @@ class TaggableStoreTest extends TestCase
             ->expects($this->never())
             ->method('prune');
 
-        $store = new TaggableStore(sys_get_temp_dir(), 0);
-        $store->setCache($cache);
+        $store = new TaggableStore(sys_get_temp_dir(), [
+            'cache' => $cache,
+            'prune_threshold' => 0,
+        ]);
 
         foreach (range(1, 21) as $entry) {
             $request = Request::create('https://foobar.com/'.$entry);

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -170,7 +170,6 @@ class TaggableStoreTest extends TestCase
         $this->assertTrue($this->store->getCache()->getItem($cacheKey)->isHit());
         $this->assertTrue($this->store->invalidateTags(['foobar']));
         $this->assertFalse($this->store->getCache()->getItem($cacheKey)->isHit());
-
     }
 
     public function testVaryResponseDropsNonVaryingOne()

--- a/tests/Unit/SymfonyCache/TaggableStoreTest.php
+++ b/tests/Unit/SymfonyCache/TaggableStoreTest.php
@@ -417,6 +417,31 @@ class TaggableStoreTest extends TestCase
         $store->cleanup();
     }
 
+    public function testPruneIsSkippedIfThresholdDisabled()
+    {
+        $innerCache = new ArrayAdapter();
+        $cache = $this->getMockBuilder(TagAwareAdapter::class)
+                    ->setConstructorArgs([$innerCache])
+                    ->setMethods(['prune'])
+                    ->getMock();
+
+        $cache
+            ->expects($this->never())
+            ->method('prune');
+
+        $store = new TaggableStore(sys_get_temp_dir(), 0);
+        $store->setCache($cache);
+
+        foreach (range(1, 21) as $entry) {
+            $request = Request::create('https://foobar.com/'.$entry);
+            $response = new Response('hello world', 200);
+
+            $store->write($request, $response);
+        }
+
+        $store->cleanup();
+    }
+
     /**
      * @param null $store
      *


### PR DESCRIPTION
Proposal for https://github.com/FriendsOfSymfony/FOSHttpCache/issues/286.
I actually did most of the work already a few months ago when trying to bring it to Symfony core so the `TaggableStore` was 80% ready and covered by all kinds of unit tests already 😄 
It has a lot of unit tests, especially for proper `Vary` handling which I implemented quite different from what the Symfony default `Store` does. I did not use it in a project yet, so I have no idea if everything works as expected, I'm just pretty sure because of the unit tests. So it would be great if someone that actually has a project where he/she could use cache invalidation with tags could test this integration and see if the docs are clear 😄 

I'll add a few comments/annotations to my own code in a few minutes.