### PR TITLE
Symfony taggable cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ cache:
 env:
   global:
     - VARNISH_VERSION=5.0
+    - DEPENDENCIES="toflar/psr6-symfony-http-cache-store:^1.0"
 
 matrix:
   fast_finish: true
   include:
       # Minimum supported versions
     - php: 5.6
-      env: VARNISH_VERSION=3.0 COMPOSER_FLAGS="--prefer-lowest"
+      env: VARNISH_VERSION=3.0 COMPOSER_FLAGS="--prefer-lowest" DEPENDENCIES=""
 
     - php: 5.6
     - php: 7.0
@@ -29,7 +30,7 @@ matrix:
     - php: 7.2
       env: DEPENDENCIES="symfony/lts:^2"
     - php: 7.2
-      env: DEPENDENCIES="symfony/lts:^3"
+      env: DEPENDENCIES="symfony/lts:^3 toflar/psr6-symfony-http-cache-store:^1.0"
 
       # Latest commit to master
     - php: 7.2
@@ -47,7 +48,7 @@ branches:
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
+    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; echo ${DEPENDENCIES}; fi;
 
 install:
   - composer update $COMPOSER_FLAGS --prefer-dist --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 ------------------
 
 * Support Symfony 4.
+
+### Testing
+
+* Upgraded phpunit to 5.7 / 6. If you use anything from the
+  `FOS\HttpCache\Test` namespace you need to update your project to use
+  PHPUnit 6 (or 5.7, if you are using PHP 5.6).
+
+### Symfony HttpCache
+
+* Added a `PurgeTagsListener` for tag based invalidation with the Symfony
+  `HttpCache` reverse caching proxy. This requires the newly created
+  [Toflar Psr6Store](https://github.com/Toflar/psr6-symfony-http-cache-store)
+  built on PSR-6 cache and supporting pruning expired cache entries.
 * Using Request::isMethodCacheable rather than Request::isMethodSafe to
   correctly handle OPTIONS and TRACE requests.
-* Upgraded phpunit to 5.7 / 6. If you use anything from the FOS\HttpCache\Test
-  namespace you need to update your project to use phpunit 6 (or 5.7, if you
-  are using PHP 5.6).
 
 2.0.2
 -----

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "monolog/monolog": "^1.0",
         "php-http/guzzle6-adapter": "^1.0.0",
         "php-http/mock-client": "^0.3.2",
+        "phpunit/phpunit": "^5.7 || ^6.0",
         "symfony/process": "^2.3 || ^3.0 || ^4.0",
-        "symfony/http-kernel": "^2.3 || ^3.0 || ^4.0",
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "symfony/http-kernel": "^2.3 || ^3.0 || ^4.0"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -24,7 +24,7 @@ Client        Purge   Refresh Ban     Tagging
 ============= ======= ======= ======= =======
 Varnish       ✓       ✓       ✓       ✓
 NGINX         ✓       ✓
-Symfony Cache ✓       ✓
+Symfony Cache ✓       ✓               ✓
 Noop          ✓       ✓       ✓       ✓
 Multiplexer   ✓       ✓       ✓       ✓
 ============= ======= ======= ======= =======

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -19,9 +19,16 @@ The response tagger uses an instance of ``TagHeaderFormatter`` to know the
 header name used to mark tags on the content and to format the tags into the
 correct header value. This library ships with a
 ``CommaSeparatedTagHeaderFormatter`` that formats an array of tags into a
-comma-separated list. This format is expected for invalidation with the
-Varnish reverse proxy. When using the default settings, everything is created
-automatically and the ``X-Cache-Tags`` header will be used::
+comma-separated list. The format for specifying the tags depends on the caching
+proxy you use and its configuration. The default settings are made to match and
+work out of the box. If you need to change anything, be aware that the caching
+proxy is configured separately from your PHP application and the
+``ResponseTagger`` - it is up to you to make sure the configurations match.
+
+For example, the :doc:`default configuration of Varnish <varnish-configuration>`
+provided in this library uses the header ``X-Cache-Tags`` with a
+comma-separated list of tags. If you don't change the ``TagHeaderFormatter`` nor
+the header name, just instantiate the response tagger with its default settings::
 
     use FOS\HttpCache\ResponseTagger;
 
@@ -29,10 +36,11 @@ automatically and the ``X-Cache-Tags`` header will be used::
 
 .. _response_tagger_optional_parameters:
 
-If you need a different behavior, you can provide your own implementation of
-the ``TagHeaderFormatter`` interface. But be aware that your
-:ref:`Varnish configuration <varnish_tagging>` has to match with the tag on the response.
-For example, to use a different header name::
+If you need a different behavior, you can provide your own
+``TagHeaderFormatter`` instance. Don't forget to also adjust your
+:doc:`proxy configuration <proxy-configuration>` to match the response. To use
+a different header name, instantiate the ``CommaSeparatedTagHeaderFormatter``
+yourself and pass it to the ``ResponseTagger``::
 
     use FOS\HttpCache\ResponseTagger;
     use FOS\HttpCache\TagHeaderFormatter;

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -13,7 +13,9 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 
 /**
  * Symfony HttpCache invalidator.
@@ -24,7 +26,7 @@ use FOS\HttpCache\SymfonyCache\PurgeListener;
  * @author David de Boer <david@driebit.nl>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
+class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, TagCapable
 {
     const HTTP_METHOD_REFRESH = 'GET';
 
@@ -54,8 +56,38 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable
         $resolver = parent::configureOptions();
         $resolver->setDefaults([
             'purge_method' => PurgeListener::DEFAULT_PURGE_METHOD,
+            'tags_method' => PurgeTagsListener::DEFAULT_TAGS_METHOD,
+            'tags_header' => PurgeTagsListener::DEFAULT_TAGS_HEADER,
+            'header_length' => 7500,
         ]);
+        $resolver->setAllowedTypes('purge_method', 'string');
+        $resolver->setAllowedTypes('tags_method', 'string');
+        $resolver->setAllowedTypes('tags_header', 'string');
+        $resolver->setAllowedTypes('header_length', 'int');
 
         return $resolver;
+    }
+
+    /**
+     * Remove/Expire cache objects based on cache tags.
+     *
+     * @param array $tags Tags that should be removed/expired from the cache
+     *
+     * @return $this
+     */
+    public function invalidateTags(array $tags)
+    {
+        $escapedTags = $this->escapeTags($tags);
+
+        $chunkSize = $this->determineTagsPerHeader($escapedTags, ',');
+
+        foreach (array_chunk($escapedTags, $chunkSize) as $tagchunk) {
+            $this->queueRequest(
+                $this->options['tags_method'],
+                '/',
+                [$this->options['tags_header'] => implode(',', $tagchunk)]);
+        }
+
+        return $this;
     }
 }

--- a/src/SymfonyCache/PurgeListener.php
+++ b/src/SymfonyCache/PurgeListener.php
@@ -81,7 +81,9 @@ class PurgeListener extends AccessControlledListener
         }
 
         $response = new Response();
-        if ($event->getKernel()->getStore()->purge($request->getUri())) {
+        $store = $event->getKernel()->getStore();
+
+        if ($store->purge($request->getUri())) {
             $response->setStatusCode(200, 'Purged');
         } else {
             $response->setStatusCode(200, 'Not found');

--- a/src/SymfonyCache/PurgeTagsListener.php
+++ b/src/SymfonyCache/PurgeTagsListener.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\SymfonyCache;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Toflar\Psr6HttpCacheStore\Psr6StoreInterface;
+
+/**
+ * Purge tags handler for the Symfony built-in HttpCache.
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ *
+ * {@inheritdoc}
+ */
+class PurgeTagsListener extends AccessControlledListener
+{
+    const DEFAULT_TAGS_METHOD = 'PURGETAGS';
+
+    const DEFAULT_TAGS_HEADER = 'X-Cache-Tags';
+
+    /**
+     * The purge tags method to use.
+     *
+     * @var string
+     */
+    private $tagsMethod;
+
+    /**
+     * The purge tags header to use.
+     *
+     * @var string
+     */
+    private $tagsHeader;
+
+    /**
+     * When creating the purge listener, you can configure an additional option.
+     *
+     * - tags_method: HTTP method that identifies purge tags requests.
+     * - tags_header: HTTP header that contains cache tags to invalidate.
+     *
+     * @param array $options Options to overwrite the default options
+     *
+     * @throws \InvalidArgumentException if unknown keys are found in $options
+     *
+     * @see AccessControlledListener::__construct
+     */
+    public function __construct(array $options = [])
+    {
+        if (!class_exists(Psr6StoreInterface::class)) {
+            throw new \Exception('Cache tag invalidation only works with the toflar/psr6-symfony-http-cache-store package. See "Symfony HttpCache Configuration" in the documentation.');
+        }
+        parent::__construct($options);
+
+        $options = $this->getOptionsResolver()->resolve($options);
+
+        $this->tagsMethod = $options['tags_method'];
+        $this->tagsHeader = $options['tags_header'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PRE_INVALIDATE => 'handlePurgeTags',
+        ];
+    }
+
+    /**
+     * Look at unsafe requests and handle purge tags requests.
+     *
+     * Prevents access when the request comes from a non-authorized client.
+     *
+     * @param CacheEvent $event
+     */
+    public function handlePurgeTags(CacheEvent $event)
+    {
+        $request = $event->getRequest();
+        if ($this->tagsMethod !== $request->getMethod()) {
+            return;
+        }
+
+        if (!$this->isRequestAllowed($request)) {
+            $event->setResponse(new Response('', 400));
+
+            return;
+        }
+
+        $response = new Response();
+        $store = $event->getKernel()->getStore();
+
+        if (!$store instanceof Psr6StoreInterface) {
+            $response->setStatusCode(400);
+            $response->setContent('Store must be an instance of '.Psr6StoreInterface::class.'. Please check your proxy configuration.');
+
+            $event->setResponse($response);
+
+            return;
+        }
+
+        if (!$request->headers->has($this->tagsHeader)) {
+            $response->setStatusCode(200, 'Not found');
+
+            $event->setResponse($response);
+
+            return;
+        }
+
+        $tags = explode(',', $request->headers->get($this->tagsHeader));
+
+        if ($store->invalidateTags($tags)) {
+            $response->setStatusCode(200, 'Purged');
+        } else {
+            $response->setStatusCode(200, 'Not found');
+        }
+
+        $event->setResponse($response);
+    }
+
+    /**
+     * Add the purge_method option.
+     *
+     * @return OptionsResolver
+     */
+    protected function getOptionsResolver()
+    {
+        $resolver = parent::getOptionsResolver();
+        $resolver->setDefaults([
+            'tags_method' => static::DEFAULT_TAGS_METHOD,
+            'tags_header' => static::DEFAULT_TAGS_HEADER,
+        ]);
+        $resolver->setAllowedTypes('tags_method', 'string');
+        $resolver->setAllowedTypes('tags_header', 'string');
+
+        return $resolver;
+    }
+}

--- a/tests/Unit/ProxyClient/SymfonyTest.php
+++ b/tests/Unit/ProxyClient/SymfonyTest.php
@@ -52,6 +52,96 @@ class SymfonyTest extends TestCase
         $symfony->purge('/url', ['X-Foo' => 'bar']);
     }
 
+    public function testInvalidateTags()
+    {
+        $symfony = new Symfony($this->httpDispatcher);
+
+        $this->httpDispatcher->shouldReceive('invalidate')->once()->with(
+            \Mockery::on(
+                function (RequestInterface $request) {
+                    $this->assertEquals('PURGETAGS', $request->getMethod());
+
+                    $this->assertEquals('/', $request->getUri());
+                    $this->assertContains('foobar,other tag', $request->getHeaderLine('X-Cache-Tags'));
+
+                    return true;
+                }
+            ),
+            true
+        );
+
+        $symfony->invalidateTags(['foobar', 'other tag']);
+    }
+
+    public function testInvalidateTagsWithALotOfTags()
+    {
+        /** @var HttpDispatcher|\PHPUnit_Framework_MockObject_MockObject $dispatcher */
+        $dispatcher = $this->createMock(HttpDispatcher::class);
+        $dispatcher
+            ->expects($this->exactly(3))
+            ->method('invalidate')
+            ->withConsecutive(
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertEquals('foobar,foobar1,foobar2,foobar3,foobar4,foobar5,foobar6,foobar7,foobar8,foobar9,foobar10', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true,
+                ],
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertEquals('foobar11,foobar12,foobar13,foobar14,foobar15,foobar16,foobar17,foobar18,foobar19,foobar20,foobar21', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true,
+                ],
+                [
+                    $this->callback(function (RequestInterface $request) {
+                        $this->assertEquals('PURGETAGS', $request->getMethod());
+                        $this->assertEquals('foobar22,foobar23,foobar24,foobar25', $request->getHeaderLine('X-Cache-Tags'));
+
+                        return true;
+                    }),
+                    true,
+                ]
+            );
+
+        $symfony = new Symfony($dispatcher, ['header_length' => 100]);
+
+        $symfony->invalidateTags([
+            'foobar',
+            'foobar1',
+            'foobar2',
+            'foobar3',
+            'foobar4',
+            'foobar5',
+            'foobar6',
+            'foobar7',
+            'foobar8',
+            'foobar9',
+            'foobar10',
+            'foobar11',
+            'foobar12',
+            'foobar13',
+            'foobar14',
+            'foobar15',
+            'foobar16',
+            'foobar17',
+            'foobar18',
+            'foobar19',
+            'foobar20',
+            'foobar21',
+            'foobar22',
+            'foobar23',
+            'foobar24',
+            'foobar25',
+        ]);
+    }
+
     public function testRefresh()
     {
         $symfony = new Symfony($this->httpDispatcher);

--- a/tests/Unit/SymfonyCache/PurgeTagsListenerTest.php
+++ b/tests/Unit/SymfonyCache/PurgeTagsListenerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\CacheEvent;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
+use Toflar\Psr6HttpCacheStore\Psr6StoreInterface;
+
+class PurgeTagsListenerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function setUp()
+    {
+        if (!class_exists(Psr6StoreInterface::class)) {
+            $this->markTestSkipped('toflar/psr6-symfony-http-cache-store not available');
+        }
+    }
+
+    /**
+     * This tests a sanity check in the AbstractControlledListener.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You may not set both a request matcher and an IP
+     */
+    public function testConstructorOverspecified()
+    {
+        new PurgeTagsListener([
+            'client_matcher' => new RequestMatcher('/forbidden'),
+            'client_ips' => ['1.2.3.4'],
+        ]);
+    }
+
+    public function testBadRequestIfWrongStore()
+    {
+        /** @var StoreInterface $store */
+        $store = \Mockery::mock(StoreInterface::class)
+            ->shouldReceive('purge')
+            ->never()
+            ->with('http://example.com/foo')
+            ->andReturn(true)
+            ->getMock();
+        $kernel = $this->getKernelMock($store);
+
+        $purgeTagsListener = new PurgeTagsListener();
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $request->headers->set('X-Cache-Tags', 'foobar,other tag');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('Store must be an instance of '.Psr6StoreInterface::class.'. Please check your proxy configuration.', $response->getContent());
+    }
+
+    public function testPurgeAllowed()
+    {
+        /** @var StoreInterface $store */
+        $store = \Mockery::mock(Psr6StoreInterface::class)
+            ->shouldReceive('invalidateTags')
+            ->once()
+            ->with(['foobar', 'other tag'])
+            ->andReturn(true)
+            ->getMock();
+        $kernel = $this->getKernelMock($store);
+
+        $purgeTagsListener = new PurgeTagsListener();
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $request->headers->set('X-Cache-Tags', 'foobar,other tag');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testPurgeAllowedMiss()
+    {
+        /** @var StoreInterface $store */
+        $store = \Mockery::mock(Psr6StoreInterface::class)
+            ->shouldReceive('invalidateTags')
+            ->once()
+            ->with(['foobar', 'other tag'])
+            ->andReturn(false)
+            ->getMock();
+        $kernel = $this->getKernelMock($store);
+
+        $purgeTagsListener = new PurgeTagsListener();
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $request->headers->set('X-Cache-Tags', 'foobar,other tag');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testPurgeForbiddenMatcher()
+    {
+        $kernel = $this->getUnusedKernelMock();
+
+        $matcher = new RequestMatcher('/forbidden');
+        $purgeTagsListener = new PurgeTagsListener(['client_matcher' => $matcher]);
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
+    public function testPurgeForbiddenIp()
+    {
+        $kernel = $this->getUnusedKernelMock();
+
+        $purgeTagsListener = new PurgeTagsListener(['client_ips' => '1.2.3.4']);
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
+    /**
+     * Configuring the method to something else should make this listener skip the request.
+     */
+    public function testOtherMethod()
+    {
+        $kernel = $this->getUnusedKernelMock();
+        $matcher = \Mockery::mock(RequestMatcher::class)
+            ->shouldNotReceive('isRequestAllowed')
+            ->getMock();
+
+        $purgeTagsListener = new PurgeTagsListener([
+            'client_matcher' => $matcher,
+            'tags_method' => 'FOO',
+        ]);
+        $request = Request::create('http://example.com/foo', 'PURGETAGS');
+        $event = new CacheEvent($kernel, $request);
+
+        $purgeTagsListener->handlePurgeTags($event);
+        $this->assertNull($event->getResponse());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage does not exist
+     */
+    public function testInvalidConfiguration()
+    {
+        new PurgeTagsListener(['stuff' => '1.2.3.4']);
+    }
+
+    /**
+     * @return CacheInvalidation|MockInterface
+     */
+    private function getKernelMock(StoreInterface $store)
+    {
+        return \Mockery::mock(CacheInvalidation::class)
+            ->shouldReceive('getStore')
+            ->once()
+            ->andReturn($store)
+            ->getMock();
+    }
+
+    /**
+     * @return CacheInvalidation|MockInterface
+     */
+    private function getUnusedKernelMock()
+    {
+        return \Mockery::mock(CacheInvalidation::class)
+            ->shouldNotReceive('getStore')
+            ->getMock();
+    }
+}


### PR DESCRIPTION
replace #373, fix #286
squashed all commits and did some tweaks to the documentation.

TODO
* [x] Once Symfony 3.4 is out: remove the `@beta` in composer.json

=> Bundle support: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/issues/403