### PR TITLE
Fix: UserContextListener set http method wrong (1.4)

### DIFF
--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -104,7 +104,9 @@ class UserContextSubscriber implements EventSubscriberInterface
                 return;
             }
 
-            if ($request->isMethodSafe()) {
+            // We must not call $request->isMethodSafe() here, because this will mess up with later configuration of the `http_method_override` that is set onto the request by the Symfony FrameworkBundle.
+            // See http://symfony.com/doc/current/reference/configuration/framework.html#configuration-framework-http-method-override
+            if (in_array($request->getRealMethod(), ['GET', 'HEAD', 'OPTIONS', 'TRACE'])) {
                 $request->headers->set($this->options['user_hash_header'], $this->getUserHash($event->getKernel(), $request));
             }
         }


### PR DESCRIPTION
Backport of https://github.com/FriendsOfSymfony/FOSHttpCache/pull/378