### PR TITLE
Better regexp for Varnish ban

### DIFF
--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -70,7 +70,7 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
         }
 
         foreach (array_chunk($escapedTags, $elems) as $tagchunk) {
-            $tagExpression = sprintf('(%s)(,.+)?$', implode('|', $tagchunk));
+            $tagExpression = sprintf('(%s)(,|$)', implode('|', $tagchunk));
             $this->ban([$this->options['tags_header'] => $tagExpression]);
         }
 

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -109,7 +109,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(mytag|othertag)(,|$))?$', $request->getHeaderLine('X-Cache-Tags'));
+                    $this->assertEquals('(mytag|othertag)(,|$)', $request->getHeaderLine('X-Cache-Tags'));
 
                     // That default BANs is taken into account also for tags as they are powered by BAN in this client.
                     $this->assertEquals('.*', $request->getHeaderLine('Test'));
@@ -134,7 +134,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(post\-1|post_type\-3)(,|$)?$', $request->getHeaderLine('X-Tags-TRex'));
+                    $this->assertEquals('(post\-1|post_type\-3)(,|$)', $request->getHeaderLine('X-Tags-TRex'));
 
                     return true;
                 }

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -109,7 +109,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(mytag|othertag)(,.+)?$', $request->getHeaderLine('X-Cache-Tags'));
+                    $this->assertEquals('(mytag|othertag)(,|$))?$', $request->getHeaderLine('X-Cache-Tags'));
 
                     // That default BANs is taken into account also for tags as they are powered by BAN in this client.
                     $this->assertEquals('.*', $request->getHeaderLine('Test'));
@@ -134,7 +134,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(post\-1|post_type\-3)(,.+)?$', $request->getHeaderLine('X-Tags-TRex'));
+                    $this->assertEquals('(post\-1|post_type\-3)(,|$)?$', $request->getHeaderLine('X-Tags-TRex'));
 
                     return true;
                 }


### PR DESCRIPTION
As explained in #393 , regexp used for banning aren't efficient.