### PR TITLE
Update X-Cache-Tags pattern to prevent objects being invalidated when  their tag ends with the tag being invalidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.1.1
+-----
+
+### Varnish
+
+* Updated X-Cache-Tags regex to prevent matching partial tags
+
+  Invalidating objects with a tag of 'bar' would have previously also have
+  invalidated objects with a tag that ends in 'bar', eg. 'foobar'. Now when
+  invalidating an object the tag name must match in full.
+
 2.1.0
 -----
 
@@ -51,27 +62,27 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 ### HTTP
 
-* **BC break:** Replaced hard coupling on Guzzle HTTP client with HTTPlug. 
+* **BC break:** Replaced hard coupling on Guzzle HTTP client with HTTPlug.
   You now need to explicitly specify a supported HTTP adapter in composer.json;
   see [installation instructions](http://foshttpcache.readthedocs.io/en/stable/installation.html).
-* **BC break:** Separated the HttpDispatcher from the proxy clients. All 
+* **BC break:** Separated the HttpDispatcher from the proxy clients. All
   existing clients still use HTTP to send invalidation requests.
 * Added support and documentation for setting a custom TTL specifically for the
   caching proxy.
 
 ### Logging
 
-* **BC break:** Renamed the log event listener from `LogSubscriber` to 
+* **BC break:** Renamed the log event listener from `LogSubscriber` to
   `LogListener`.
-  
+
 ### Proxy clients
 
-* **BC break**: Renamed the `Ban`, `Purge`, `Refresh` and `Tag` interfaces to 
+* **BC break**: Renamed the `Ban`, `Purge`, `Refresh` and `Tag` interfaces to
   `BanCapable`, `PurgeCapable`, `RefreshCapable` and `TagCapable`.
 
 ### Tagging
 
-* **BC break:** Moved tag invalidation to `CacheInvalidator`, and renamed 
+* **BC break:** Moved tag invalidation to `CacheInvalidator`, and renamed
   `TagHandler` to `ResponseTagger`.
 * Abstracting tags by adding new `TagCapable` for ProxyClients.
 * Added `strict` option to `ResponseTagger` that throws an exception when empty
@@ -97,21 +108,21 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 ### Symfony HttpCache
 
-* **BC break:** Renamed all event listeners to `XxListener` instead of 
+* **BC break:** Renamed all event listeners to `XxListener` instead of
   `XxSubscriber`.
-* **BC break:** Constructors for `PurgeListener` and `RefreshListener` now use 
+* **BC break:** Constructors for `PurgeListener` and `RefreshListener` now use
   an options array for customization.
-* **BC break:** Converted abstract event dispatching kernel class 
+* **BC break:** Converted abstract event dispatching kernel class
   `EventDispatchingHttpCache` to a trait, which now provides the `addSubscriber`
-  and `addListener` methods. In your `AppCache`, replace 
-  `AppCache extends EventDispatchingHttpInterface` with a 
-  `use EventDispatchingHttpCache;` statement. 
+  and `addListener` methods. In your `AppCache`, replace
+  `AppCache extends EventDispatchingHttpInterface` with a
+  `use EventDispatchingHttpCache;` statement.
 * The user context by default does not use a hardcoded hash for anonymous users
   but does a hash lookup. You can still configure a hardcoded hash.  
 
 ### Testing
 
-* **BC break:** Refactored the proxy client test system into traits. Removed 
+* **BC break:** Refactored the proxy client test system into traits. Removed
   `ProxyTestCase`; use the traits `CacheAssertions` and `HttpCaller` instead.
 * Added HTTP method parameter to `HttpCaller::getResponse()`.
 

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -66,7 +66,7 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
         $chunkSize = $this->determineTagsPerHeader($escapedTags, '|');
 
         foreach (array_chunk($escapedTags, $chunkSize) as $tagchunk) {
-            $tagExpression = sprintf('(%s)(,|$)', implode('|', $tagchunk));
+            $tagExpression = sprintf('(^|,)(%s)(,|$)', implode('|', $tagchunk));
             $this->ban([$this->options['tags_header'] => $tagExpression]);
         }
 

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -109,7 +109,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(mytag|othertag)(,|$)', $request->getHeaderLine('X-Cache-Tags'));
+                    $this->assertEquals('(^|,)(mytag|othertag)(,|$)', $request->getHeaderLine('X-Cache-Tags'));
 
                     // That default BANs is taken into account also for tags as they are powered by BAN in this client.
                     $this->assertEquals('.*', $request->getHeaderLine('Test'));
@@ -134,7 +134,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('(post\-1|post_type\-3)(,|$)', $request->getHeaderLine('X-Tags-TRex'));
+                    $this->assertEquals('(^|,)(post\-1|post_type\-3)(,|$)', $request->getHeaderLine('X-Tags-TRex'));
 
                     return true;
                 }


### PR DESCRIPTION
If you have two objects, one with a tag of 'foobar' and another with a tag of 'bar', currently if you invalidate objects that have a tag of 'bar', you actually invalidate both of these objects since the first objects tag ends in 'bar'.

This pull request should prevent that from happening by only invalidating objects that match the full key.