### PR TITLE
PurgeTagsListener: checking existence of Psr6StoreInterface incorrect

### DIFF
--- a/src/SymfonyCache/PurgeTagsListener.php
+++ b/src/SymfonyCache/PurgeTagsListener.php
@@ -56,7 +56,7 @@ class PurgeTagsListener extends AccessControlledListener
      */
     public function __construct(array $options = [])
     {
-        if (!class_exists(Psr6StoreInterface::class)) {
+        if (!interface_exists(Psr6StoreInterface::class)) {
             throw new \Exception('Cache tag invalidation only works with the toflar/psr6-symfony-http-cache-store package. See "Symfony HttpCache Configuration" in the documentation.');
         }
         parent::__construct($options);


### PR DESCRIPTION
I tried using the PurgeTagsListener but after successfully installing (composer requiring) the toflar/psr6-symfony-http-cache-store package and including the PurgeTagsListener in my AppCache.php I was hitting the Exception from Line 60: 'Cache tag invalidation only works with the toflar/psr6-symfony-http-cache-store package. See "Symfony HttpCache Configuration" in the documentation.'

System: Symfony 3.4.4 + friendsofsymfony/http-cache-bundle 2.1.2 + (friendsofsymfony/http-cache 2.1.1) with the Symfony Reverse Proxy

Problem:
class_exists returns false for interface 

Solution:
use  "interface_exists(Psr6StoreInterface::class)" to successfully check for existence of package. 