### PR TITLE
prevent installing with symfony/http-foundation 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
             "FOS\\HttpCache\\Tests\\": "tests/"
         }
     },
+    "conflict": {
+        "symfony/http-foundation": ">=4.0"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.4.x-dev"


### PR DESCRIPTION
we are not compatible with that version. hopefully this should fix the build.