### PR TITLE
Symfony HttpCache Tag Invalidation: Do not check for missing host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.1.2
+-----
+
+#### Symfony HttpCache
+
+* Fixed bug in Symfony tag invalidation.
+  Do not check if host is missing in request creation.
+
 2.1.1
 -----
 
@@ -27,7 +35,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 
 ### Symfony HttpCache
 
-* Cache tagging supprt for Symfony HttpCache
+* Cache tagging support for Symfony HttpCache
 
   Added a `PurgeTagsListener` for tag based invalidation with the Symfony
   `HttpCache` reverse caching proxy. This requires the newly created

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -85,7 +85,9 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
             $this->queueRequest(
                 $this->options['tags_method'],
                 '/',
-                [$this->options['tags_header'] => implode(',', $tagchunk)]);
+                [$this->options['tags_header'] => implode(',', $tagchunk)],
+                false
+            );
         }
 
         return $this;


### PR DESCRIPTION
Fixed bug in Symfony Tag Invalidation.

Do not check if host is missing in request creation.