### PR TITLE
use std in main vcl too

### DIFF
--- a/resources/config/varnish/fos_custom_ttl.vcl
+++ b/resources/config/varnish/fos_custom_ttl.vcl
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import std;
-
 /**
  * Read a custom TTL header for the time to live information, to be used
  * instead of s-maxage.
+ *
+ * This needs an `import std;` in your main VCL. If you do not already import
+ * the standard vmod, you need to add it there.
  */
 sub fos_custom_ttl_backend_response {
     if (beresp.http.X-Reverse-Proxy-TTL) {

--- a/tests/Functional/Fixtures/varnish/custom_ttl.vcl
+++ b/tests/Functional/Fixtures/varnish/custom_ttl.vcl
@@ -1,5 +1,7 @@
 vcl 4.0;
 
+import std;
+
 include "../../../../resources/config/varnish/fos_debug.vcl";
 include "../../../../resources/config/varnish/fos_custom_ttl.vcl";
 


### PR DESCRIPTION
reproduce error report from slack that `use std` can only be in one vcl.