### PR TITLE
[RFC] Added MaxHeaderValueLengthFormatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
     - php: 7.2
       env: VARNISH_VERSION=4.1 VARNISH_MODULES_VERSION=0.9.1
 
+    # Test Symfony LTS versions
+    - php: 7.2
+      env: DEPENDENCIES="symfony/lts:^3 toflar/psr6-symfony-http-cache-store:^1.0"
+
       # Latest commit to master
     - php: 7.2
       env: STABILITY="dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 env:
   global:
     - VARNISH_VERSION=5.1
-    - DEPENDENCIES="toflar/psr6-symfony-http-cache-store:^1.0"
+    - DEPENDENCIES="toflar/psr6-symfony-http-cache-store:^1.1.2"
 
 matrix:
   fast_finish: true
@@ -30,7 +30,7 @@ matrix:
     - php: 7.2
       env: DEPENDENCIES="symfony/lts:^2"
     - php: 7.2
-      env: DEPENDENCIES="symfony/lts:^3 toflar/psr6-symfony-http-cache-store:^1.0"
+      env: DEPENDENCIES="symfony/lts:^3 toflar/psr6-symfony-http-cache-store:^1.1.2"
 
       # Latest commit to master
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,10 @@ matrix:
     - php: 7.2
       env: VARNISH_VERSION=4.1 VARNISH_MODULES_VERSION=0.9.1
 
-      # Test Symfony LTS versions
-    - php: 7.2
-      env: DEPENDENCIES="symfony/lts:^2"
-    - php: 7.2
-      env: DEPENDENCIES="symfony/lts:^3 toflar/psr6-symfony-http-cache-store:^1.1.2"
-
       # Latest commit to master
     - php: 7.2
       env: STABILITY="dev"
+
   allow_failures:
     # Dev-master is allowed to fail.
     - env: STABILITY="dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.5.0
+-----
+
+### Tagging
+
+* Added: `MaxHeaderValueLengthFormatter` to allow splitting cache tag headers into
+  multiple headers.
+
 2.4.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "symfony/process": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0"
     },
+    "conflict": {
+        "toflar/psr6-symfony-http-cache-store": "<1.1.2"
+    },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",
         "monolog/monolog": "For logging issues while invalidating"

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "php-http/client-implementation": "^1.0.0",
         "php-http/client-common": "^1.1.0",
         "php-http/message": "^1.0.0",
-        "php-http/discovery": "^1.0",
-        "toflar/psr6-symfony-http-cache-store": "^1.1.2"
+        "php-http/discovery": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,13 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0.0",
-        "symfony/event-dispatcher": "^2.3 || ^3.0 || ^4.0",
-        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher": "^3.4 || ^4.0",
+        "symfony/options-resolver": "^3.4 || ^4.0",
         "php-http/client-implementation": "^1.0.0",
         "php-http/client-common": "^1.1.0",
         "php-http/message": "^1.0.0",
-        "php-http/discovery": "^1.0"
+        "php-http/discovery": "^1.0",
+        "toflar/psr6-symfony-http-cache-store": "^1.1.2"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.5",
@@ -35,8 +36,8 @@
         "php-http/guzzle6-adapter": "^1.0.0",
         "php-http/mock-client": "^0.3.2",
         "phpunit/phpunit": "^5.7 || ^6.0",
-        "symfony/process": "^2.3 || ^3.0 || ^4.0",
-        "symfony/http-kernel": "^2.3 || ^3.0 || ^4.0"
+        "symfony/process": "^3.4 || ^4.0",
+        "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",
@@ -54,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.4.x-dev"
+            "dev-master": "2.5.x-dev"
         }
     }
 }

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -56,6 +56,23 @@ empty tags::
 
     $responseTagger = new ResponseTagger(['strict' => true]);
 
+
+Depending on how many tags your system usually generates your tags header value
+might get pretty long. In that case, again depending on your setup, you might run
+into server exceptions because the header value is too big to send. Mostly, this
+value seems to be about 4KB. The only thing you can do in such a case is to split
+up one header into multiple ones. Of course, your proxy then has to support multiple
+header values otherwise you'll end up with a proxy that only reads the first line
+of your tags. This library ships with a ``MaxHeaderValueLengthFormatter`` that does
+the splitting for you. You give it an inner formatter and the maximum length like so::
+
+
+    use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
+    use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter
+
+    $inner = new CommaSeparatedTagHeaderFormatter('X-Cache-Tags', ',');
+    $formatter new MaxHeaderValueLengthFormatter($inner, 4096);
+
 Usage
 ~~~~~
 

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -64,9 +64,14 @@ Depending on how many tags your system usually generates your tags header value
 might get pretty long. In that case, again depending on your setup, you might run
 into server exceptions because the header value is too big to send. Mostly, this
 value seems to be about 4KB. The only thing you can do in such a case is to split
-up one header into multiple ones. Of course, your proxy then has to support multiple
-header values otherwise you'll end up with a proxy that only reads the first line
-of your tags. This library ships with a ``MaxHeaderValueLengthFormatter`` that does
+up one header into multiple ones.
+
+ .. note::
+
+    Of course, your proxy then has to support multiple header values otherwise
+    you'll end up with a proxy that only reads the first line of your tags.
+
+This library ships with a ``MaxHeaderValueLengthFormatter`` that does
 the splitting for you. You give it an inner formatter and the maximum length like so::
 
 

--- a/doc/response-tagging.rst
+++ b/doc/response-tagging.rst
@@ -57,6 +57,9 @@ empty tags::
     $responseTagger = new ResponseTagger(['strict' => true]);
 
 
+Working with large numbers of tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Depending on how many tags your system usually generates your tags header value
 might get pretty long. In that case, again depending on your setup, you might run
 into server exceptions because the header value is too big to send. Mostly, this
@@ -72,6 +75,10 @@ the splitting for you. You give it an inner formatter and the maximum length lik
 
     $inner = new CommaSeparatedTagHeaderFormatter('X-Cache-Tags', ',');
     $formatter new MaxHeaderValueLengthFormatter($inner, 4096);
+
+.. note::
+
+    Both, Varnish and Symfony HttpCache support multiple cache tag headers.
 
 Usage
 ~~~~~

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -226,7 +226,7 @@ configure the HTTP method and header used for tag purging:
 
   **default**: ``X-Cache-Tags``
 
-* **tags_invalidate_path**: Path to where the invalidation request with the headers should be sent to.
+* **tags_invalidate_path**: Path on the caching proxy to which the purge tags request should be sent.
 
   **default**: ``/``
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -226,6 +226,10 @@ configure the HTTP method and header used for tag purging:
 
   **default**: ``X-Cache-Tags``
 
+* **tags_invalidate_path**: Path to where the invalidation request with the headers should be sent to.
+
+  **default**: ``/``
+
 To get cache tagging support, register the ``PurgeTagsListener`` and use the
 ``Psr6Store`` in your ``AppCache``::
 

--- a/src/Exception/InvalidTagException.php
+++ b/src/Exception/InvalidTagException.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCache\Exception;
 
 /**
- * Thrown during tagging with an empty value.
+ * Thrown during tagging with an invalid value.
  */
 class InvalidTagException extends \InvalidArgumentException implements HttpCacheException
 {

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -58,13 +58,13 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
             'purge_method' => PurgeListener::DEFAULT_PURGE_METHOD,
             'tags_method' => PurgeTagsListener::DEFAULT_TAGS_METHOD,
             'tags_header' => PurgeTagsListener::DEFAULT_TAGS_HEADER,
-            'tags_path' => '/',
+            'tags_invalidate_path' => '/',
             'header_length' => 7500,
         ]);
         $resolver->setAllowedTypes('purge_method', 'string');
         $resolver->setAllowedTypes('tags_method', 'string');
         $resolver->setAllowedTypes('tags_header', 'string');
-        $resolver->setAllowedTypes('tags_path', 'string');
+        $resolver->setAllowedTypes('tags_invalidate_path', 'string');
         $resolver->setAllowedTypes('header_length', 'int');
 
         return $resolver;
@@ -86,7 +86,7 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
         foreach (array_chunk($escapedTags, $chunkSize) as $tagchunk) {
             $this->queueRequest(
                 $this->options['tags_method'],
-                $this->options['tags_path'],
+                $this->options['tags_invalidate_path'],
                 [$this->options['tags_header'] => implode(',', $tagchunk)],
                 false
             );

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -58,11 +58,13 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
             'purge_method' => PurgeListener::DEFAULT_PURGE_METHOD,
             'tags_method' => PurgeTagsListener::DEFAULT_TAGS_METHOD,
             'tags_header' => PurgeTagsListener::DEFAULT_TAGS_HEADER,
+            'tags_path' => '/',
             'header_length' => 7500,
         ]);
         $resolver->setAllowedTypes('purge_method', 'string');
         $resolver->setAllowedTypes('tags_method', 'string');
         $resolver->setAllowedTypes('tags_header', 'string');
+        $resolver->setAllowedTypes('tags_path', 'string');
         $resolver->setAllowedTypes('header_length', 'int');
 
         return $resolver;
@@ -84,7 +86,7 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
         foreach (array_chunk($escapedTags, $chunkSize) as $tagchunk) {
             $this->queueRequest(
                 $this->options['tags_method'],
-                '/',
+                $this->options['tags_path'],
                 [$this->options['tags_header'] => implode(',', $tagchunk)],
                 false
             );

--- a/src/SymfonyCache/PurgeTagsListener.php
+++ b/src/SymfonyCache/PurgeTagsListener.php
@@ -117,7 +117,13 @@ class PurgeTagsListener extends AccessControlledListener
             return;
         }
 
-        $tags = explode(',', $request->headers->get($this->tagsHeader));
+        $tags = [];
+
+        foreach ($request->headers->get($this->tagsHeader, '', false) as $v) {
+            foreach (explode(',', $v) as $tag) {
+                $tags[] = $tag;
+            }
+        }
 
         if ($store->invalidateTags($tags)) {
             $response->setStatusCode(200, 'Purged');

--- a/src/TagHeaderFormatter/MaxHeaderValueLengthFormatter.php
+++ b/src/TagHeaderFormatter/MaxHeaderValueLengthFormatter.php
@@ -17,7 +17,7 @@ use FOS\HttpCache\Exception\InvalidTagException;
  * A header formatter that splits the value(s) from a given
  * other header formatter (e.g. the CommaSeparatedTagHeaderFormatter)
  * into multiple headers making sure none of the header values
- * exceeds the configured limit
+ * exceeds the configured limit.
  *
  * @author Yanick Witschi <yanick.witschi@terminal42.ch>
  */
@@ -40,7 +40,7 @@ class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
      * use up just one byte.
      *
      * @param TagHeaderFormatter $inner
-     * @param int $maxHeaderValueLength
+     * @param int                $maxHeaderValueLength
      */
     public function __construct(TagHeaderFormatter $inner, $maxHeaderValueLength = 4096)
     {
@@ -56,7 +56,6 @@ class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
         $this->inner->getTagsHeaderName();
     }
 
-
     /**
      * {@inheritdoc}
      */
@@ -67,7 +66,7 @@ class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
 
         foreach ($values as $value) {
             if ($this->isHeaderTooLong($value)) {
-                list ($firstTags, $secondTags) = $this->splitTagsInHalves($tags);
+                list($firstTags, $secondTags) = $this->splitTagsInHalves($tags);
 
                 $newValues[] = (array) $this->getTagsHeaderValue($firstTags);
                 $newValues[] = (array) $this->getTagsHeaderValue($secondTags);
@@ -101,10 +100,11 @@ class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
      * @param array $tags
      *
      * @return array
+     *
      * @throws InvalidTagException
      */
-    private function splitTagsInHalves(array $tags) {
-
+    private function splitTagsInHalves(array $tags)
+    {
         if (1 === count($tags)) {
             throw new InvalidTagException(sprintf(
                 'You configured a maximum header length of %d but the tag "%s" is too long.',
@@ -114,6 +114,7 @@ class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
         }
 
         $size = ceil(count($tags) / 2);
+
         return array_chunk($tags, $size);
     }
 }

--- a/src/TagHeaderFormatter/MaxHeaderValueLengthFormatter.php
+++ b/src/TagHeaderFormatter/MaxHeaderValueLengthFormatter.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\TagHeaderFormatter;
+
+use FOS\HttpCache\Exception\InvalidTagException;
+
+/**
+ * A header formatter that splits the value(s) from a given
+ * other header formatter (e.g. the CommaSeparatedTagHeaderFormatter)
+ * into multiple headers making sure none of the header values
+ * exceeds the configured limit
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class MaxHeaderValueLengthFormatter implements TagHeaderFormatter
+{
+    /**
+     * @var TagHeaderFormatter
+     */
+    private $inner;
+
+    /**
+     * @var int
+     */
+    private $maxHeaderValueLength;
+
+    /**
+     * The default value of the maximum header length is 4096 because most
+     * servers limit header values to 4kb.
+     * HTTP messages cannot carry characters outside the ISO-8859-1 standard so they all
+     * use up just one byte.
+     *
+     * @param TagHeaderFormatter $inner
+     * @param int $maxHeaderValueLength
+     */
+    public function __construct(TagHeaderFormatter $inner, $maxHeaderValueLength = 4096)
+    {
+        $this->inner = $inner;
+        $this->maxHeaderValueLength = $maxHeaderValueLength;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTagsHeaderName()
+    {
+        $this->inner->getTagsHeaderName();
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTagsHeaderValue(array $tags)
+    {
+        $values = (array) $this->inner->getTagsHeaderValue($tags);
+        $newValues = [[]];
+
+        foreach ($values as $value) {
+            if ($this->isHeaderTooLong($value)) {
+                list ($firstTags, $secondTags) = $this->splitTagsInHalves($tags);
+
+                $newValues[] = (array) $this->getTagsHeaderValue($firstTags);
+                $newValues[] = (array) $this->getTagsHeaderValue($secondTags);
+            } else {
+                $newValues[] = [$value];
+            }
+        }
+
+        $newValues = array_merge(...$newValues);
+
+        if (1 === count($newValues)) {
+            return $newValues[0];
+        }
+
+        return $newValues;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function isHeaderTooLong($value)
+    {
+        return mb_strlen($value) > $this->maxHeaderValueLength;
+    }
+
+    /**
+     * Split an array of tags in two more or less equal sized arrays.
+     *
+     * @param array $tags
+     *
+     * @return array
+     * @throws InvalidTagException
+     */
+    private function splitTagsInHalves(array $tags) {
+
+        if (1 === count($tags)) {
+            throw new InvalidTagException(sprintf(
+                'You configured a maximum header length of %d but the tag "%s" is too long.',
+                $this->maxHeaderValueLength,
+                $tags[0]
+            ));
+        }
+
+        $size = ceil(count($tags) / 2);
+        return array_chunk($tags, $size);
+    }
+}

--- a/src/TagHeaderFormatter/TagHeaderFormatter.php
+++ b/src/TagHeaderFormatter/TagHeaderFormatter.php
@@ -39,7 +39,7 @@ interface TagHeaderFormatter
      *
      * @param array $tags
      *
-     * @return string
+     * @return string|string[]
      */
     public function getTagsHeaderValue(array $tags);
 }

--- a/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
+++ b/src/Test/PHPUnit/AbstractCacheConstraintTrait.php
@@ -54,6 +54,18 @@ trait AbstractCacheConstraintTrait
                 $message .= sprintf("\nStatus code of response is %s.", $other->getStatusCode());
             }
 
+            $message .= "\nThe response headers are:\n\n";
+
+            foreach ($other->getHeaders() as $name => $values) {
+                foreach ($values as $value) {
+                    $message .= $name.': '.$value;
+                }
+            }
+
+            $body = $other->getBody();
+            $body->rewind();
+            $message .= sprintf("\nThe response body is:\n\n %s", $body->getContents());
+
             throw new \RuntimeException($message);
         }
 

--- a/src/Test/SymfonyTest.php
+++ b/src/Test/SymfonyTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\Test;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\Symfony;
 use FOS\HttpCache\Test\Proxy\SymfonyProxy;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 /**
  * Clears the Symfony HttpCache proxy between tests.
@@ -121,12 +122,16 @@ trait SymfonyTest
                 $this->getHostName().':'.$this->getCachingProxyPort()
             );
 
-            $this->proxyClient = new Symfony($httpDispatcher, [
-                    'purge_method' => 'NOTIFY',
-                    'tags_method' => 'UNSUBSCRIBE',
-                    'tags_invalidate_path' => '/symfony.php/',
-                ]
-            );
+            $config = [
+                'purge_method' => 'NOTIFY',
+            ];
+
+            if (class_exists(Psr6Store::class)) {
+                $config['tags_method'] = 'UNSUBSCRIBE';
+                $config['tags_invalidate_path'] = '/symfony.php/';
+            }
+
+            $this->proxyClient = new Symfony($httpDispatcher, $config);
         }
 
         return $this->proxyClient;

--- a/src/Test/SymfonyTest.php
+++ b/src/Test/SymfonyTest.php
@@ -124,7 +124,7 @@ trait SymfonyTest
             $this->proxyClient = new Symfony($httpDispatcher, [
                     'purge_method' => 'NOTIFY',
                     'tags_method' => 'UNSUBSCRIBE',
-                    'tags_path' => '/symfony.php/',
+                    'tags_invalidate_path' => '/symfony.php/',
                 ]
             );
         }

--- a/src/Test/SymfonyTest.php
+++ b/src/Test/SymfonyTest.php
@@ -123,6 +123,8 @@ trait SymfonyTest
 
             $this->proxyClient = new Symfony($httpDispatcher, [
                     'purge_method' => 'NOTIFY',
+                    'tags_method' => 'UNSUBSCRIBE',
+                    'tags_path' => '/symfony.php/',
                 ]
             );
         }

--- a/tests/Functional/Fixtures/Symfony/AppCache.php
+++ b/tests/Functional/Fixtures/Symfony/AppCache.php
@@ -16,6 +16,7 @@ use FOS\HttpCache\SymfonyCache\CustomTtlListener;
 use FOS\HttpCache\SymfonyCache\DebugListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use FOS\HttpCache\SymfonyCache\RefreshListener;
 use FOS\HttpCache\SymfonyCache\UserContextListener;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,6 +35,7 @@ class AppCache extends HttpCache implements CacheInvalidation
 
         $this->addSubscriber(new CustomTtlListener());
         $this->addSubscriber(new PurgeListener(['purge_method' => 'NOTIFY']));
+        $this->addSubscriber(new PurgeTagsListener(['tags_method' => 'UNSUBSCRIBE']));
         $this->addSubscriber(new RefreshListener());
         $this->addSubscriber(new UserContextListener());
         if (isset($options['debug']) && $options['debug']) {

--- a/tests/Functional/Fixtures/Symfony/AppCache.php
+++ b/tests/Functional/Fixtures/Symfony/AppCache.php
@@ -37,7 +37,7 @@ class AppCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new CustomTtlListener());
         $this->addSubscriber(new PurgeListener(['purge_method' => 'NOTIFY']));
 
-        if (!class_exists(Psr6Store::class)) {
+        if (class_exists(Psr6Store::class)) {
             $this->addSubscriber(new PurgeTagsListener(['tags_method' => 'UNSUBSCRIBE']));
         }
 

--- a/tests/Functional/Fixtures/Symfony/AppCache.php
+++ b/tests/Functional/Fixtures/Symfony/AppCache.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpCache\SurrogateInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class AppCache extends HttpCache implements CacheInvalidation
 {
@@ -35,7 +36,11 @@ class AppCache extends HttpCache implements CacheInvalidation
 
         $this->addSubscriber(new CustomTtlListener());
         $this->addSubscriber(new PurgeListener(['purge_method' => 'NOTIFY']));
-        $this->addSubscriber(new PurgeTagsListener(['tags_method' => 'UNSUBSCRIBE']));
+
+        if (!class_exists(Psr6Store::class)) {
+            $this->addSubscriber(new PurgeTagsListener(['tags_method' => 'UNSUBSCRIBE']));
+        }
+
         $this->addSubscriber(new RefreshListener());
         $this->addSubscriber(new UserContextListener());
         if (isset($options['debug']) && $options['debug']) {

--- a/tests/Functional/Fixtures/Symfony/AppKernel.php
+++ b/tests/Functional/Fixtures/Symfony/AppKernel.php
@@ -33,6 +33,18 @@ class AppKernel implements HttpKernelInterface
                 $response->setCache(['max_age' => 3600, 'public' => true]);
 
                 return $response;
+            case '/tags':
+                $response = new Response(microtime(true));
+                $response->setCache(['max_age' => 3600, 'public' => true]);
+                $response->headers->set('X-Cache-Tags', 'tag1,tag2');
+
+                return $response;
+            case '/tags_multi_header':
+                $response = new Response(microtime(true));
+                $response->setCache(['max_age' => 3600, 'public' => true]);
+                $response->headers->set('X-Cache-Tags', ['tag1', 'tag2']);
+
+                return $response;
             case '/negotiation':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);

--- a/tests/Functional/Fixtures/web/symfony.php
+++ b/tests/Functional/Fixtures/web/symfony.php
@@ -20,8 +20,14 @@ $loader = require_once __DIR__.'/../../../../vendor/autoload.php';
 
 $symfonyProxy = new SymfonyProxy();
 
+if (class_exists(Psr6Store::class)) {
+    $store = new Psr6Store(['cache_directory' => $symfonyProxy->getCacheDir(), 'cache_tags_header' => 'X-Cache-Tags']);
+} else {
+    $store = new Store($symfonyProxy->getCacheDir());
+}
+
 $kernel = new AppKernel();
-$kernel = new AppCache($kernel, new Psr6Store(['cache_directory' => $symfonyProxy->getCacheDir(), 'cache_tags_header' => 'X-Cache-Tags']), null, ['debug' => true]);
+$kernel = new AppCache($kernel, $store, null, ['debug' => true]);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/tests/Functional/Fixtures/web/symfony.php
+++ b/tests/Functional/Fixtures/web/symfony.php
@@ -14,13 +14,14 @@ use FOS\HttpCache\Tests\Functional\Fixtures\Symfony\AppCache;
 use FOS\HttpCache\Tests\Functional\Fixtures\Symfony\AppKernel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\Store;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 $loader = require_once __DIR__.'/../../../../vendor/autoload.php';
 
 $symfonyProxy = new SymfonyProxy();
 
 $kernel = new AppKernel();
-$kernel = new AppCache($kernel, new Store($symfonyProxy->getCacheDir()), null, ['debug' => true]);
+$kernel = new AppCache($kernel, new Psr6Store(['cache_directory' => $symfonyProxy->getCacheDir(), 'cache_tags_header' => 'X-Cache-Tags']), null, ['debug' => true]);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/tests/Functional/Fixtures/web/tags_multi_header.php
+++ b/tests/Functional/Fixtures/web/tags_multi_header.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+header('Cache-Control: max-age=3600');
+header('Content-Type: text/html');
+header('X-Cache-Tags: tag1');
+header('X-Cache-Tags: tag2');
+header('X-Cache-Debug: 1');

--- a/tests/Functional/ProxyClient/InvalidateTagsAssertions.php
+++ b/tests/Functional/ProxyClient/InvalidateTagsAssertions.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Functional\ProxyClient;
+
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
+
+/**
+ * Assertions that do the cache tag invalidation operations.
+ */
+trait InvalidateTagsAssertions
+{
+    /**
+     * Asserting that purging cache tags leads to invalidated content.
+     *
+     * @param PurgeCapable $proxyClient The client to send purge instructions to the cache
+     * @param array        $tags        The cache tags to invalidate
+     * @param string       $path        The path to get and purge, defaults to /tags.php
+     */
+    protected function assertInvalidateTags(TagCapable $proxyClient, array $cacheTags, $path = '/tags.php')
+    {
+        $this->assertMiss($this->getResponse($path));
+        $this->assertHit($this->getResponse($path));
+
+        $proxyClient->invalidateTags($cacheTags)->flush();
+        $this->assertMiss($this->getResponse($path));
+    }
+}

--- a/tests/Functional/ProxyClient/SymfonyProxyClientTest.php
+++ b/tests/Functional/ProxyClient/SymfonyProxyClientTest.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\Tests\Functional\ProxyClient;
 
 use FOS\HttpCache\Test\SymfonyTestCase;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 /**
  * @group webserver
@@ -50,11 +51,19 @@ class SymfonyProxyClientTest extends SymfonyTestCase
 
     public function testInvalidateTags()
     {
+        if (!class_exists(Psr6Store::class)) {
+            $this->markTestSkipped('Needs PSR-6 store to be installed.');
+        }
+
         $this->assertInvalidateTags($this->getProxyClient(), ['tag1'], '/symfony.php/tags');
     }
 
     public function testInvalidateTagsMultiHeader()
     {
+        if (!class_exists(Psr6Store::class)) {
+            $this->markTestSkipped('Needs PSR-6 store to be installed.');
+        }
+
         $this->assertInvalidateTags($this->getProxyClient(), ['tag2'], '/symfony.php/tags_multi_header');
     }
 }

--- a/tests/Functional/ProxyClient/SymfonyProxyClientTest.php
+++ b/tests/Functional/ProxyClient/SymfonyProxyClientTest.php
@@ -21,6 +21,7 @@ class SymfonyProxyClientTest extends SymfonyTestCase
 {
     use RefreshAssertions;
     use PurgeAssertions;
+    use InvalidateTagsAssertions;
 
     public function testPurge()
     {
@@ -45,5 +46,15 @@ class SymfonyProxyClientTest extends SymfonyTestCase
     public function testRefreshContentType()
     {
         $this->assertRefresh($this->getProxyClient(), '/symfony.php/negotiation');
+    }
+
+    public function testInvalidateTags()
+    {
+        $this->assertInvalidateTags($this->getProxyClient(), ['tag1'], '/symfony.php/tags');
+    }
+
+    public function testInvalidateTagsMultiHeader()
+    {
+        $this->assertInvalidateTags($this->getProxyClient(), ['tag2'], '/symfony.php/tags_multi_header');
     }
 }

--- a/tests/Unit/TagHeaderFormatter/MaxHeaderValueLengthFormatterTest.php
+++ b/tests/Unit/TagHeaderFormatter/MaxHeaderValueLengthFormatterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\TagHeaderFormatter;
+
+
+use FOS\HttpCache\Exception\InvalidTagException;
+use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
+use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter;
+use PHPUnit\Framework\TestCase;
+
+class MaxHeaderValueLengthFormatterTest extends TestCase
+{
+    public function testNotTooLong()
+    {
+        $formatter = $this->getFormatter(50);
+        $tags = ['foo', 'bar', 'baz'];
+
+        $this->assertSame('foo,bar,baz', $formatter->getTagsHeaderValue($tags));
+    }
+
+    /**
+     * @dataProvider tooLongProvider
+     * @param int $maxLength
+     * @param array $tags
+     * @param mixed $expectedHeaderValue
+     */
+    public function testTooLong($maxLength, $tags, $expectedHeaderValue)
+    {
+        $formatter = $this->getFormatter($maxLength);
+        $this->assertSame($expectedHeaderValue, $formatter->getTagsHeaderValue($tags));
+    }
+
+    public function testOneTagExceedsMaximum()
+    {
+        $this->expectException(InvalidTagException::class);
+        $this->expectExceptionMessage('You configured a maximum header length of 3 but the tag "way-too-long-tag" is too long.');
+
+        $formatter = $this->getFormatter(3);
+        $formatter->getTagsHeaderValue(['way-too-long-tag']);
+    }
+
+    /**
+     * @param int $maxLength
+     *
+     * @return MaxHeaderValueLengthFormatter
+     */
+    private function getFormatter($maxLength)
+    {
+        return new MaxHeaderValueLengthFormatter(
+            new CommaSeparatedTagHeaderFormatter(),
+            $maxLength
+        );
+    }
+
+    public function tooLongProvider()
+    {
+        return [
+            [3, ['foo', 'bar', 'baz'], ['foo', 'bar', 'baz']],
+            [6, ['foo', 'bar', 'baz'], ['foo', 'bar', 'baz']], // with the , that equals 7
+            [7, ['foo', 'bar', 'baz'], ['foo,bar', 'baz']],
+            [50, ['foo', 'bar', 'baz'], 'foo,bar,baz'], // long enough, must not be an array
+        ];
+    }
+}

--- a/tests/Unit/TagHeaderFormatter/MaxHeaderValueLengthFormatterTest.php
+++ b/tests/Unit/TagHeaderFormatter/MaxHeaderValueLengthFormatterTest.php
@@ -11,7 +11,6 @@
 
 namespace FOS\HttpCache\Tests\Unit\TagHeaderFormatter;
 
-
 use FOS\HttpCache\Exception\InvalidTagException;
 use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
 use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter;
@@ -29,7 +28,8 @@ class MaxHeaderValueLengthFormatterTest extends TestCase
 
     /**
      * @dataProvider tooLongProvider
-     * @param int $maxLength
+     *
+     * @param int   $maxLength
      * @param array $tags
      * @param mixed $expectedHeaderValue
      */

--- a/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/AbstractCacheConstraintTest.php
@@ -21,7 +21,7 @@ abstract class AbstractCacheConstraintTest extends TestCase
     protected function getResponseMock()
     {
         $mock = \Mockery::mock(
-            '\Psr\Http\Message\ResponseInterface[hasHeader,getHeaderLine,getStatusCode]'
+            '\Psr\Http\Message\ResponseInterface[hasHeader,getHeaderLine,getStatusCode,getHeaders,getBody]'
         );
 
         return $mock;

--- a/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
+++ b/tests/Unit/Test/PHPUnit/IsCacheHitConstraintTest.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\Tests\Unit\Test\PHPUnit;
 
 use FOS\HttpCache\Test\PHPUnit\IsCacheHitConstraint;
+use GuzzleHttp\Psr7\Stream;
 
 // phpunit 5 has forward compatibility classes but missed this one
 if (!class_exists('\PHPUnit\Framework\ExpectationFailedException')) {
@@ -40,6 +41,8 @@ class IsCacheHitConstraintTest extends AbstractCacheConstraintTest
             ->shouldReceive('hasHeader')->with('cache-header')->andReturn(true)
             ->shouldReceive('getHeaderLine')->with('cache-header')->once()->andReturn('MISS')
             ->shouldReceive('getStatusCode')->andReturn(500)
+            ->shouldReceive('getHeaders')->andReturn([])
+            ->shouldReceive('getBody')->andReturn(new Stream(fopen('php://temp', 'r+')))
             ->getMock();
 
         $this->constraint->evaluate($response);
@@ -54,6 +57,8 @@ class IsCacheHitConstraintTest extends AbstractCacheConstraintTest
         $response = $this->getResponseMock()
             ->shouldReceive('hasHeader')->with('cache-header')->once()->andReturn(false)
             ->shouldReceive('getStatusCode')->andReturn(200)
+            ->shouldReceive('getHeaders')->andReturn([])
+            ->shouldReceive('getBody')->andReturn(new Stream(fopen('php://temp', 'r+')))
             ->getMock();
 
         $this->constraint->evaluate($response);


### PR DESCRIPTION
This is an idea on how we could try to solve the maximum length of the header values in the `ResponseTagger`. We already have `TagHeaderFormatters` so I thought I'll write one that takes an inner formatter and splits the tags of this one to make sure it does not exceed the max length. This would allow to use this formatter to limit the header value length of any other formatter (the built in CSV or your very own) very easily (a pretty cool concept I find 😄 ).

For this to work, however, I had to adjust the return value of the `TagHeaderFormatter` interface and I know that in theory this is a BC break. **BUT:** I wanted to discuss this here because it's really only a theoretical BC break. So what I did is I changed this:

```php
    /**
     * Get the value for the HTTP tag header.
     *
     * This concatenates all tags and ensures correct encoding.
     *
     * @param array $tags
     *
     * @return string
     */
    public function getTagsHeaderValue(array $tags);
```

to this:

```php
    /**
     * Get the value for the HTTP tag header.
     *
     * This concatenates all tags and ensures correct encoding.
     *
     * @param array $tags
     *
     * @return string|string[]
     */
    public function getTagsHeaderValue(array $tags);
```

So basically, it now allows an array of strings to be returned. This means all the existing formatters that return a string are just fine. Only the ones **calling** the method must also deal with an array return value. And this in fact should've **always been the case** because both, the PSR-7 `Response::withHeader()` as well as the Symfony `$response->headers->set()` accept an array to support multi-value headers. So, in theory this is a BC break but I don't think anyone will be affected.

Wdyt?