### PR TITLE
Added a case for banning user context hash object. Partial fix for #482

### DIFF
--- a/resources/config/varnish/fos_ban.vcl
+++ b/resources/config/varnish/fos_ban.vcl
@@ -21,6 +21,12 @@ sub fos_ban_recv {
                 // the left side is the response header, the right side the invalidation header
                 + " && obj.http.X-Cache-Tags ~ " + req.http.X-Cache-Tags
             );
+        } elseif(req.http.Cookie) {
+            ban("obj.http.X-Host ~ " + req.http.X-Host
+                + " && obj.http.X-Url ~ " + req.http.X-Url
+                + " && obj.http.content-type ~ " + req.http.X-Content-Type
+                + " && obj.http.Cookie ~ " + req.http.Cookie
+            );
         } else {
             ban("obj.http.X-Host ~ " + req.http.X-Host
                 + " && obj.http.X-Url ~ " + req.http.X-Url
@@ -37,6 +43,9 @@ sub fos_ban_backend_response {
     # Set ban-lurker friendly custom headers
     set beresp.http.X-Url = bereq.url;
     set beresp.http.X-Host = bereq.http.host;
+    if (bereq.http.accept ~ "application/vnd.fos.user-context-hash") {
+        set beresp.http.Cookie = ";" + bereq.http.Cookie;
+    }
 }
 
 sub fos_ban_deliver {
@@ -46,6 +55,7 @@ sub fos_ban_deliver {
         # Remove ban-lurker friendly custom headers when delivering to client
         unset resp.http.X-Url;
         unset resp.http.X-Host;
+        unset resp.http.Cookie;
 
         # Unset the tagged cache headers
         unset resp.http.X-Cache-Tags;


### PR DESCRIPTION
This is a partial fix for banning user context hash objects from Varnish server, with out setting the right header (X-Content-Type) this would still ban all the cached content for the specified user identifier header (session id) instead of just the user context hash object. To ban only the hash response, we can either change the case in ban VCL to ban **accept** header or the PHP code to set the **X-Content-Type** header.