### PR TITLE
Remove xkey header in vcl_deliver when not in debug mode

### DIFF
--- a/doc/varnish-configuration.rst
+++ b/doc/varnish-configuration.rst
@@ -214,6 +214,10 @@ and include ``resources/config/varnish/fos_tags_xkey.vcl`` in your VCL:
             call fos_tags_xkey_recv;
         }
 
+        sub vcl_deliver {
+            call fos_tags_xkey_deliver;
+        }
+
 Note that there is no xkey VCL file for Varnish version 3 because the
 varnish-modules are only available for Varnish 4.1 or newer.
 

--- a/resources/config/varnish/fos_tags_xkey.vcl
+++ b/resources/config/varnish/fos_tags_xkey.vcl
@@ -34,3 +34,10 @@ sub fos_tags_xkey_recv {
         return (synth(200, "Purged "+req.http.n-gone+" objects, expired "+req.http.n-softgone+" objects"));
     }
 }
+
+sub fos_tags_xkey_deliver {
+    if (!resp.http.X-Cache-Debug) {
+        // Remove tag headers when delivering to non debug client
+        unset resp.http.xkey;
+    }
+}

--- a/tests/Functional/Fixtures/varnish/fos_xkey.vcl
+++ b/tests/Functional/Fixtures/varnish/fos_xkey.vcl
@@ -29,4 +29,5 @@ sub vcl_backend_response {
 sub vcl_deliver {
     call fos_debug_deliver;
     call fos_ban_deliver;
+    call fos_tags_xkey_deliver;
 }


### PR DESCRIPTION
Avoid leaking internal id info from applications in tags by unsetting the xkey header in prod.

Extracted from code material for talk on [Take your Http caching to the next level with xkey & Fastly](https://twitter.com/andrerom/status/1045806806298185729).