### PR TITLE
[VCL] Keep user context headers in debug mode

### DIFF
--- a/resources/config/varnish-3/fos_user_context.vcl
+++ b/resources/config/varnish-3/fos_user_context.vcl
@@ -88,16 +88,18 @@ sub fos_user_context_deliver {
         return (restart);
     }
 
-    # If we get here, this is a real response that gets sent to the client.
+    # If we get here, this is a real response that gets sent to the client and we do some cleanup if not in debug.
 
-    # Remove the vary on context user hash, this is nothing public. Keep all
-    # other vary headers.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
-    set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
-    if (resp.http.Vary == "") {
-        remove resp.http.Vary;
+    if (!resp.http.X-Cache-Debug) {
+        # Remove the vary on context user hash, this is nothing public. Keep all
+        # other vary headers.
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
+        set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
+        if (resp.http.Vary == "") {
+            remove resp.http.Vary;
+        }
+
+        # Sanity check to prevent ever exposing the hash to a client.
+        remove resp.http.X-User-Context-Hash;
     }
-
-    # Sanity check to prevent ever exposing the hash to a client.
-    remove resp.http.X-User-Context-Hash;
 }

--- a/resources/config/varnish/fos_user_context.vcl
+++ b/resources/config/varnish/fos_user_context.vcl
@@ -86,16 +86,18 @@ sub fos_user_context_deliver {
         return (restart);
     }
 
-    # If we get here, this is a real response that gets sent to the client.
+    # If we get here, this is a real response that gets sent to the client and we do some cleanup if not in debug.
 
-    # Remove the vary on context user hash, this is nothing public. Keep all
-    # other vary headers.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
-    set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
-    if (resp.http.Vary == "") {
-        unset resp.http.Vary;
+    if (!resp.http.X-Cache-Debug) {
+        # Remove the vary on context user hash, this is nothing public. Keep all
+        # other vary headers.
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i),? *X-User-Context-Hash *", "");
+        set resp.http.Vary = regsub(resp.http.Vary, "^, *", "");
+        if (resp.http.Vary == "") {
+            unset resp.http.Vary;
+        }
+
+        # Sanity check to prevent ever exposing the hash to a client.
+        unset resp.http.X-User-Context-Hash;
     }
-
-    # Sanity check to prevent ever exposing the hash to a client.
-    unset resp.http.X-User-Context-Hash;
 }


### PR DESCRIPTION
To improve debugging, and to be consistent with other cleanup keep headers if we are in debug mode.

NOTE: If you know about a way to return early in a sane way here, we can do this without changing all the lines here.