### PR TITLE
Fixed HttpCacheProvider interface not allowing to return null

### DIFF
--- a/src/SymfonyCache/HttpCacheAware.php
+++ b/src/SymfonyCache/HttpCacheAware.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 trait HttpCacheAware
 {
     /**
-     * @var HttpKernelInterface
+     * @var HttpKernelInterface|null
      */
     private $httpCache;
 

--- a/src/SymfonyCache/HttpCacheAware.php
+++ b/src/SymfonyCache/HttpCacheAware.php
@@ -24,7 +24,7 @@ trait HttpCacheAware
     private $httpCache;
 
     /**
-     * @return HttpKernelInterface
+     * @return HttpKernelInterface|null
      */
     public function getHttpCache()
     {

--- a/src/SymfonyCache/HttpCacheProvider.php
+++ b/src/SymfonyCache/HttpCacheProvider.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 interface HttpCacheProvider
 {
     /**
-     * @return HttpKernelInterface
+     * @return HttpKernelInterface|null
      */
     public function getHttpCache();
 }

--- a/src/SymfonyCache/KernelDispatcher.php
+++ b/src/SymfonyCache/KernelDispatcher.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\SymfonyCache;
 
 use FOS\HttpCache\Exception\ExceptionCollection;
+use FOS\HttpCache\Exception\ProxyUnreachableException;
 use FOS\HttpCache\ProxyClient\Dispatcher;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -95,6 +96,10 @@ class KernelDispatcher implements Dispatcher
         $exceptions = new ExceptionCollection();
 
         $httpCache = $this->httpCacheProvider->getHttpCache();
+
+        if (null === $httpCache) {
+            throw new ProxyUnreachableException('Cannot reach Symfony HttpCache as the Kernel does not know about it.');
+        }
 
         foreach ($queue as $request) {
             try {

--- a/src/SymfonyCache/KernelDispatcher.php
+++ b/src/SymfonyCache/KernelDispatcher.php
@@ -98,7 +98,7 @@ class KernelDispatcher implements Dispatcher
         $httpCache = $this->httpCacheProvider->getHttpCache();
 
         if (null === $httpCache) {
-            throw new ProxyUnreachableException('Cannot reach Symfony HttpCache as the Kernel does not know about it.');
+            throw new ProxyUnreachableException('Kernel did not return a HttpCache instance. Did you forget $kernel->setHttpCache($cacheKernel) in your front controller?');
         }
 
         foreach ($queue as $request) {

--- a/tests/Unit/SymfonyCache/KernelDispatcherTest.php
+++ b/tests/Unit/SymfonyCache/KernelDispatcherTest.php
@@ -60,7 +60,7 @@ class KernelDispatcherTest extends TestCase
     public function testFlushWithoutHttpCache()
     {
         $this->expectException(ProxyUnreachableException::class);
-        $this->expectExceptionMessage('Cannot reach Symfony HttpCache as the Kernel does not know about it.');
+        $this->expectExceptionMessage('Kernel did not return a HttpCache instance. Did you forget $kernel->setHttpCache($cacheKernel) in your front controller?');
 
         $kernel = $this->createMock(HttpCacheProvider::class);
         $kernel->expects($this->once())


### PR DESCRIPTION
That's actually a bug in the interface documentation because just because a kernel is `HttpCacheAware` does not mean it really is able to return an HttpCache instance.
It's just aware of it meaning the kernel is able to receive one and return it back but still, if nobody ever gives it one, it cannot magically create one out of the blue :)