### PR TITLE
allow httplug 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,15 @@
         "php": "^5.6 || ^7.0.0",
         "symfony/event-dispatcher": "^3.4 || ^4.0",
         "symfony/options-resolver": "^3.4 || ^4.0",
-        "php-http/client-implementation": "^1.0.0",
-        "php-http/client-common": "^1.1.0",
-        "php-http/message": "^1.0.0",
-        "php-http/discovery": "^1.0"
+        "php-http/client-implementation": "^1.0 || ^2.0",
+        "php-http/client-common": "^1.1.0 || ^2.0",
+        "php-http/message": "^1.0 || ^2.0",
+        "php-http/discovery": "^1.0 || ^2.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.5",
         "monolog/monolog": "^1.0",
-        "php-http/guzzle6-adapter": "^1.0.0",
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "php-http/mock-client": "^0.3.2",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "symfony/process": "^3.4 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "mockery/mockery": "~0.9.5",
         "monolog/monolog": "^1.0",
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
-        "php-http/mock-client": "^0.3.2",
+        "php-http/mock-client": "^1.2",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "symfony/process": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0"


### PR DESCRIPTION
lets wait with merging until php-http/client-common has a 2.0 release and we see php-http/guzzle6-adapter 2.0 being installed in the travis build.