### PR TITLE
lock sphinx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_script:
     cat /etc/apt/sources.list
     sudo apt-get update -qq
     sudo apt-get install -qq varnish
-  - if [ "$DOCCHECK" = true ]; then sudo apt-get install -qq python-sphinx enchant; fi
+  - if [ "$DOCCHECK" = true ]; then sudo apt-get install -qq enchant; fi
   - if [ "$DOCCHECK" = true ]; then sudo pip install -r doc/requirements.txt; fi
   - if [ "$VARNISH_MODULES_VERSION" != "" ]; then sh ./tests/install-varnish-modules.sh; fi
   # Install NGINX

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+sphinx ~= 1.3.0
 git+https://github.com/fabpot/sphinx-php.git
 sphinx-rtd-theme
 sphinxcontrib-spelling


### PR DESCRIPTION
the build failed.

meanwhile, when specifying python: 3.6, we get a bunch of ssl errors when trying to install.