### PR TITLE
Fixed missing request type in event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.7.0
+-----
+
+### Symfony HttpCache
+
+* Added request type to the CacheEvent.
+
 2.6.0
 -----
 

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\SymfonyCache;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Event raised by the HttpCache kernel.
@@ -38,17 +39,24 @@ class CacheEvent extends Event
     private $response;
 
     /**
+     * @var int
+     */
+    private $requestType;
+
+    /**
      * Make sure your $kernel implements CacheInvalidationInterface.
      *
-     * @param CacheInvalidation $kernel   the kernel raising with this event
-     * @param Request           $request  the request being processed
-     * @param Response          $response the response, if available
+     * @param CacheInvalidation $kernel      the kernel raising with this event
+     * @param Request           $request     the request being processed
+     * @param Response          $response    the response, if available
+     * @param int               $requestType the request type (default KernelInterface::MASTER_REQUEST)
      */
-    public function __construct(CacheInvalidation $kernel, Request $request, Response $response = null)
+    public function __construct(CacheInvalidation $kernel, Request $request, Response $response = null, $requestType = KernelInterface::MASTER_REQUEST)
     {
         $this->kernel = $kernel;
         $this->request = $request;
         $this->response = $response;
+        $this->requestType = $requestType;
     }
 
     /**
@@ -69,6 +77,16 @@ class CacheEvent extends Event
     public function getRequest()
     {
         return $this->request;
+    }
+
+    /**
+     * Get the request type.
+     *
+     * @return int
+     */
+    public function getRequestType()
+    {
+        return $this->requestType;
     }
 
     /**

--- a/tests/Unit/SymfonyCache/CacheEventTest.php
+++ b/tests/Unit/SymfonyCache/CacheEventTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\Tests\Unit\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\CacheEvent;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class CacheEventTest extends TestCase
+{
+    /**
+     * @var CacheInvalidation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $kernel;
+
+    public function setUp()
+    {
+        $this->kernel = $this->createMock(CacheInvalidation::class);
+    }
+
+    public function testEventGetters()
+    {
+        $request = Request::create('/');
+
+        $event = new CacheEvent($this->kernel, $request);
+
+        $this->assertSame($this->kernel, $event->getKernel());
+        $this->assertSame($request, $event->getRequest());
+        $this->assertNull($event->getResponse());
+        $this->assertSame(KernelInterface::MASTER_REQUEST, $event->getRequestType());
+
+        $response = new Response();
+
+        $event = new CacheEvent($this->kernel, $request, $response, HttpKernelInterface::SUB_REQUEST);
+
+        $this->assertSame($this->kernel, $event->getKernel());
+        $this->assertSame($request, $event->getRequest());
+        $this->assertSame($response, $event->getResponse());
+        $this->assertSame(KernelInterface::SUB_REQUEST, $event->getRequestType());
+    }
+}


### PR DESCRIPTION
I noticed there's a major issue in the `CacheEvent` because it's lacking the request type. If you want to send a request via `$httpCache = $event->getKernel()->handle($$event->getRequest())` in an event listener yourself, you don't know the request type which means it's always going to be a master request even though it should be a sub request (e.g. Symfony's `AbstractSurrogateHandler`).