### PR TITLE
Fix tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 cache:

--- a/tests/Functional/Varnish/UserContextTestCase.php
+++ b/tests/Functional/Varnish/UserContextTestCase.php
@@ -52,12 +52,12 @@ abstract class UserContextTestCase extends VarnishTestCase
         $this->assertContextCache($cachedResponse2->getHeaderLine('X-HashCache'));
         $this->assertHit($cachedResponse2);
 
-        $headResponse1 = $this->getResponse('/user_context.php', ['Cookie' => ['0=foo'], [], 'HEAD']);
+        $headResponse1 = $this->getResponse('/user_context.php', ['Cookie' => ['0=foo']], 'HEAD');
         $this->assertEquals('foo', $headResponse1->getHeaderLine('X-HashTest'));
         $this->assertContextCache($headResponse1->getHeaderLine('X-HashCache'));
         $this->assertHit($headResponse1);
 
-        $headResponse2 = $this->getResponse('/user_context.php', ['Cookie' => ['0=bar'], [], 'HEAD']);
+        $headResponse2 = $this->getResponse('/user_context.php', ['Cookie' => ['0=bar']], 'HEAD');
         $this->assertEquals('bar', $headResponse2->getHeaderLine('X-HashTest'));
         $this->assertContextCache($headResponse2->getHeaderLine('X-HashCache'));
         $this->assertHit($headResponse2);


### PR DESCRIPTION
Found so far:
- xenial is now default on travis, this does not seems to work with Varnish 3, stick to trusty for now
   - Bump back to xenial once we can remove Varnish3
- New version of `guzzlehttp/psr7/src/MessageTrait` is a bit more strict, and detects invalid parameters used in UserContextTestCase.php