### PR TITLE
Use LegacyEventDispatcherProxy for Symfony 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.8.0
+-----
+
+### General
+
+* Use `LegacyEventDispatcherProxy` for Symfony >= 4.3 to avoid deprecation messages.
+
 2.7.0
 -----
 

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -25,6 +25,7 @@ use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\ProxyClient\Symfony;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 /**
@@ -143,7 +144,11 @@ class CacheInvalidator
     public function getEventDispatcher()
     {
         if (!$this->eventDispatcher) {
-            $this->eventDispatcher = new EventDispatcher();
+            if (class_exists(LegacyEventDispatcherProxy::class)) {
+                $this->eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
+            } else {
+                $this->eventDispatcher = new EventDispatcher();
+            }
         }
 
         return $this->eventDispatcher;

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\SymfonyCache;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -54,8 +55,12 @@ trait EventDispatchingHttpCache
      */
     public function getEventDispatcher()
     {
-        if (null === $this->eventDispatcher) {
-            $this->eventDispatcher = new EventDispatcher();
+        if (!$this->eventDispatcher) {
+            if (class_exists(LegacyEventDispatcherProxy::class)) {
+                $this->eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
+            } else {
+                $this->eventDispatcher = new EventDispatcher();
+            }
         }
 
         return $this->eventDispatcher;

--- a/src/Test/EventDispatchingHttpCacheTestCase.php
+++ b/src/Test/EventDispatchingHttpCacheTestCase.php
@@ -62,6 +62,8 @@ abstract class EventDispatchingHttpCacheTestCase extends TestCase
             'allow_revalidate' => false,
             'stale_while_revalidate' => 2,
             'stale_if_error' => 60,
+            'trace_level' => 'full',
+            'trace_header' => 'FOSHttpCache',
         ];
 
         $refHttpCache = new \ReflectionClass(HttpCache::class);

--- a/tests/Unit/CacheInvalidatorTest.php
+++ b/tests/Unit/CacheInvalidatorTest.php
@@ -32,6 +32,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class CacheInvalidatorTest extends TestCase
 {
@@ -257,8 +258,13 @@ class CacheInvalidatorTest extends TestCase
         /** @var MockInterface|Varnish $proxyClient */
         $proxyClient = \Mockery::mock(Varnish::class);
 
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
+        } else {
+            $eventDispatcher = new EventDispatcher();
+        }
+
         $cacheInvalidator = new CacheInvalidator($proxyClient);
-        $eventDispatcher = new EventDispatcher();
         $cacheInvalidator->setEventDispatcher($eventDispatcher);
         $this->assertSame($eventDispatcher, $cacheInvalidator->getEventDispatcher());
     }
@@ -268,8 +274,13 @@ class CacheInvalidatorTest extends TestCase
         /** @var MockInterface|Varnish $proxyClient */
         $proxyClient = \Mockery::mock(Varnish::class);
 
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $eventDispatcher = LegacyEventDispatcherProxy::decorate(new EventDispatcher());
+        } else {
+            $eventDispatcher = new EventDispatcher();
+        }
+
         $cacheInvalidator = new CacheInvalidator($proxyClient);
-        $eventDispatcher = new EventDispatcher();
         $cacheInvalidator->setEventDispatcher($eventDispatcher);
         $this->expectException(\Exception::class);
         $cacheInvalidator->setEventDispatcher($eventDispatcher);


### PR DESCRIPTION
This should fix the following deprecation message:

> User Deprecated: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.