### PR TITLE
Extend Event class from symfony/contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 ### General
 
 * Use `LegacyEventDispatcherProxy` for Symfony >= 4.3 to avoid deprecation messages.
+* Event classes now extend `Symfony\Contracts\EventDispatcher\Event` if available.
 
 2.7.0
 -----

--- a/src/Event.php
+++ b/src/Event.php
@@ -11,9 +11,21 @@
 
 namespace FOS\HttpCache;
 
-use Symfony\Component\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\EventDispatcher\Event as BaseEventDeprecated;
+use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
 
-class Event extends BaseEvent
+// Symfony 4.3 BC layer
+if (class_exists(BaseEvent::class)) {
+    class MiddleManEvent extends BaseEvent
+    {
+    }
+} else {
+    class MiddleManEvent extends BaseEventDeprecated
+    {
+    }
+}
+
+class Event extends MiddleManEvent
 {
     private $exception;
 

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -11,17 +11,29 @@
 
 namespace FOS\HttpCache\SymfonyCache;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as EventDeprecated;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+// Symfony 4.3 BC layer
+if (class_exists(Event::class)) {
+    class MiddleManCacheEvent extends Event
+    {
+    }
+} else {
+    class MiddleManCacheEvent extends EventDeprecated
+    {
+    }
+}
 
 /**
  * Event raised by the HttpCache kernel.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-class CacheEvent extends Event
+class CacheEvent extends MiddleManCacheEvent
 {
     /**
      * @var CacheInvalidation


### PR DESCRIPTION
This should fix the following deprecation message:

> User Deprecated: The "FOS\HttpCache\Event" class extends "Symfony\Component\EventDispatcher\Event" that is deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead.

To be merged after https://github.com/FriendsOfSymfony/FOSHttpCache/pull/463