### PR TITLE
Add support for Symfony 5.0 #SymfonyHackday

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0.0",
-        "symfony/event-dispatcher": "^3.4 || ^4.0",
-        "symfony/options-resolver": "^3.4 || ^4.0",
+        "symfony/event-dispatcher": "^3.4 || ^4.3 || ^5.0",
+        "symfony/options-resolver": "^3.4 || ^4.3 || ^5.0",
         "php-http/client-implementation": "^1.0 || ^2.0",
         "php-http/client-common": "^1.1.0 || ^2.0",
         "php-http/message": "^1.0 || ^2.0",
@@ -35,8 +35,8 @@
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "php-http/mock-client": "^1.2",
         "phpunit/phpunit": "^5.7 || ^6.0",
-        "symfony/process": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0"
+        "symfony/process": "^3.4 || ^4.3 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0"
     },
     "conflict": {
         "toflar/psr6-symfony-http-cache-store": "<1.1.2"

--- a/src/BaseEvent.php
+++ b/src/BaseEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache;
+
+use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
+use Symfony\Component\EventDispatcher\Event as OldEvent;
+
+if (class_exists(ContractEvent::class)) {
+    class BaseEvent extends ContractEvent
+    {
+    }
+} else {
+    /**
+     * @codeCoverageIgnore
+     * @ignore This is purely for 3.4 comparability.
+     */
+    class BaseEvent extends OldEvent
+    {
+    }
+}

--- a/src/BaseEvent.php
+++ b/src/BaseEvent.php
@@ -11,8 +11,8 @@
 
 namespace FOS\HttpCache;
 
-use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 use Symfony\Component\EventDispatcher\Event as OldEvent;
+use Symfony\Contracts\EventDispatcher\Event as ContractEvent;
 
 if (class_exists(ContractEvent::class)) {
     class BaseEvent extends ContractEvent

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -311,13 +311,25 @@ class CacheInvalidator
                 $event = new Event();
                 $event->setException($exception);
                 if ($exception instanceof ProxyResponseException) {
-                    $this->getEventDispatcher()->dispatch(Events::PROXY_RESPONSE_ERROR, $event);
+                    $this->dispatch($event, Events::PROXY_RESPONSE_ERROR);
                 } elseif ($exception instanceof ProxyUnreachableException) {
-                    $this->getEventDispatcher()->dispatch(Events::PROXY_UNREACHABLE_ERROR, $event);
+                    $this->dispatch($event, Events::PROXY_UNREACHABLE_ERROR);
                 }
             }
 
             throw $exceptions;
+        }
+    }
+
+    private function dispatch(Event $event, $eventName)
+    {
+        // LegacyEventDispatcherProxy exists in Symfony >= 4.3
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            // New Symfony 4.3 EventDispatcher signature
+            $this->getEventDispatcher()->dispatch($event, $eventName);
+        } else {
+            // Old EventDispatcher signature
+            $this->getEventDispatcher()->dispatch($eventName, $event);
         }
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -11,8 +11,6 @@
 
 namespace FOS\HttpCache;
 
-use Symfony\Component\EventDispatcher\Event as BaseEvent;
-
 class Event extends BaseEvent
 {
     private $exception;

--- a/src/SymfonyCache/CacheEvent.php
+++ b/src/SymfonyCache/CacheEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\HttpCache\SymfonyCache;
 
-use Symfony\Component\EventDispatcher\Event;
+use FOS\HttpCache\BaseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-class CacheEvent extends Event
+class CacheEvent extends BaseEvent
 {
     /**
      * @var CacheInvalidation

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -145,7 +145,16 @@ trait EventDispatchingHttpCache
     {
         if ($this->getEventDispatcher()->hasListeners($name)) {
             $event = new CacheEvent($this, $request, $response, $requestType);
-            $this->getEventDispatcher()->dispatch($name, $event);
+
+            // LegacyEventDispatcherProxy exists in Symfony >= 4.3
+            if (class_exists(LegacyEventDispatcherProxy::class)) {
+                // New Symfony 4.3 EventDispatcher signature
+                $this->getEventDispatcher()->dispatch($event, $name);
+            } else {
+                // Old EventDispatcher signature
+                $this->getEventDispatcher()->dispatch($name, $event);
+            }
+
             $response = $event->getResponse();
         }
 


### PR DESCRIPTION
Adds support for use with Symfony 5.0, I pulled in #467 here and went instead for a base event class over approach in #464



Closes #464
Closes #467

#SymfonyHackday