### PR TITLE
v1.4: Add generic error response to request tampering response

### DIFF
--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -117,7 +117,7 @@ class UserContextSubscriber implements EventSubscriberInterface
             if ($request->headers->get('accept') === $this->options['user_hash_accept_header']
                 || null !== $request->headers->get($this->options['user_hash_header'])
             ) {
-                $event->setResponse(new Response('Bad request given', 400));
+                $event->setResponse(new Response('bad request', 400));
 
                 return;
             }

--- a/src/SymfonyCache/UserContextSubscriber.php
+++ b/src/SymfonyCache/UserContextSubscriber.php
@@ -117,7 +117,7 @@ class UserContextSubscriber implements EventSubscriberInterface
             if ($request->headers->get('accept') === $this->options['user_hash_accept_header']
                 || null !== $request->headers->get($this->options['user_hash_header'])
             ) {
-                $event->setResponse(new Response('', 400));
+                $event->setResponse(new Response('Bad request given', 400));
 
                 return;
             }

--- a/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
+++ b/tests/Unit/SymfonyCache/UserContextSubscriberTest.php
@@ -75,6 +75,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
         $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('bad request',  $response->getContent());
     }
 
     /**
@@ -93,6 +94,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
         $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('bad request',  $response->getContent());
     }
 
     /**


### PR DESCRIPTION
# Problem
After spending many more hours than I would like to say on an issue ultimately pertaining to #284 I think it would be a fairly good idea of giving some indicator of what went wrong.

# Proposed solution
Given the fairly odd place at which this code can be executed in the symfony request cycle it is fairly difficult to find a good way to do logging here without making significant changes. Beyond that the handler is run so early there is no guarentee symfony's core error handling will be set up by the time this code is executed. Blackholeing the error however makes it immensely difficult (beyond setting up xdebug :sweat: ) to find where the error is been given. 

Therefore returning a response with the error that is generic enough for a attacker to not necessarily know where it is coming from, even with targeted searches https://github.com/search?q=bad+request&type=Code , but verbose enough for a developer actively searing their code base for the exception to find it .

Let me know if you need any more input from me on this! Thanks!