### PR TITLE
Fix exception creation in `HttpDispatcher`

### DIFF
--- a/src/ProxyClient/HttpDispatcher.php
+++ b/src/ProxyClient/HttpDispatcher.php
@@ -142,7 +142,7 @@ class HttpDispatcher implements Dispatcher
                 try {
                     $promises[] = $this->httpClient->sendAsyncRequest($proxyRequest);
                 } catch (\Exception $e) {
-                    $exceptions->add(new InvalidArgumentException($e));
+                    $exceptions->add(new InvalidArgumentException($e->getMessage(), $e->getCode(), $e));
                 }
             }
         }
@@ -156,7 +156,7 @@ class HttpDispatcher implements Dispatcher
                 $exceptions->add(ProxyUnreachableException::proxyUnreachable($exception));
             } catch (\Exception $exception) {
                 // @codeCoverageIgnoreStart
-                $exceptions->add(new InvalidArgumentException($exception));
+                $exceptions->add(new InvalidArgumentException($exception->getMessage(), $exception->getCode(), $exception));
                 // @codeCoverageIgnoreEnd
             }
         }


### PR DESCRIPTION
[`FOS\HttpCache\Exception\InvalidArgumentException`](https://github.com/FriendsOfSymfony/FOSHttpCache/blob/39999a6c60d8bdc756436dd0739202d897d29351/src/Exception/InvalidArgumentException.php) just extends the base one, without any custom code. Which means the first parameter should be the message, followed by the code and then the previous exception.