### PR TITLE
Add a flag to keep the custom ttl header

### DIFF
--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -31,6 +31,11 @@ class CustomTtlListener implements EventSubscriberInterface
     private $ttlHeader;
 
     /**
+     * @var bool
+     */
+    private $keepTtlHeader;
+
+    /**
      * Header used for backing up the s-maxage.
      *
      * @var string
@@ -39,10 +44,12 @@ class CustomTtlListener implements EventSubscriberInterface
 
     /**
      * @param string $ttlHeader The header that is used to specify the TTL header
+     * @param bool $keepTtlHeader
      */
-    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL')
+    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false)
     {
         $this->ttlHeader = $ttlHeader;
+        $this->keepTtlHeader = $keepTtlHeader;
     }
 
     /**
@@ -85,7 +92,10 @@ class CustomTtlListener implements EventSubscriberInterface
                 $response->headers->addCacheControlDirective('s-maxage', $smaxage);
             }
         }
-        $response->headers->remove($this->ttlHeader);
+
+        if (!$this->keepTtlHeader) {
+            $response->headers->remove($this->ttlHeader);
+        }
         $response->headers->remove(static::SMAXAGE_BACKUP);
     }
 

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -44,7 +44,7 @@ class CustomTtlListener implements EventSubscriberInterface
 
     /**
      * @param string $ttlHeader The header that is used to specify the TTL header
-     * @param bool $keepTtlHeader
+     * @param bool   $keepTtlHeader Keep the custom ttl header for later usage
      */
     public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false)
     {

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -43,8 +43,8 @@ class CustomTtlListener implements EventSubscriberInterface
     public const SMAXAGE_BACKUP = 'FOS-Smaxage-Backup';
 
     /**
-     * @param string $ttlHeader The header that is used to specify the TTL header
-     * @param bool   $keepTtlHeader Keep the custom ttl header for later usage
+     * @param string $ttlHeader     The header that is used to specify the TTL header
+     * @param bool   $keepTtlHeader Keep the custom TTL header for later usage
      */
     public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false)
     {

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -43,8 +43,8 @@ class CustomTtlListener implements EventSubscriberInterface
     public const SMAXAGE_BACKUP = 'FOS-Smaxage-Backup';
 
     /**
-     * @param string $ttlHeader     The header that is used to specify the TTL header
-     * @param bool   $keepTtlHeader Keep the custom TTL header for later usage
+     * @param string $ttlHeader     The header name that is used to specify the time to live
+     * @param bool   $keepTtlHeader Keep the custom TTL header on the response for later usage (e.g. debugging)
      */
     public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false)
     {


### PR DESCRIPTION
Allows to keep the custom ttl header for additional caches.