### PR TITLE
Send the right revision hash to Scrutinizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,4 +205,4 @@ jobs:
       - name: Upload coverage
         run: |
           wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml
+          php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml --revision=${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Scrutinizer fails for all PRs with this message:
```
Code coverage data is not yet available.
Code Coverage was not sent to Scrutinizer.
Make sure that you have set-up your external service correctly.
You can find more information on this in the documentation:

    https://scrutinizer-ci.com/docs/tools/external-code-coverage/

If you need help you can also email support@scrutinizer-ci.com.
```

Sending the right revision hash should fix the issue.