### PR TITLE
Fix badges

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,13 @@
 imports:
   - php
 
+build:
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run
+
 tools:
   external_code_coverage:
     timeout: 600

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 FOSHttpCache
 ============
-[![Build Status](https://travis-ci.org/FriendsOfSymfony/FOSHttpCache.svg?branch=master)](https://travis-ci.org/FriendsOfSymfony/FOSHttpCache)
+[![CI](https://github.com/FriendsOfSymfony/FOSHttpCache/actions/workflows/ci.yml/badge.svg)](https://github.com/FriendsOfSymfony/FOSHttpCache/actions/workflows/ci.yml)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSHttpCache/badges/quality-score.png?s=bc263d4deb45becdb1469b71e8630c5e65efdcf4)](https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSHttpCache/)
 [![Code Coverage](https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSHttpCache/badges/coverage.png?s=a19df7bb7e830642fb937891aebe8c3e1c9f59c0)](https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSHttpCache/)
 [![Latest Stable Version](https://poser.pugx.org/friendsofsymfony/http-cache/v/stable.svg)](https://packagist.org/packages/friendsofsymfony/http-cache)


### PR DESCRIPTION
I've replaced the Travis badge by one from the Github actions.

Also the Scrutinizer badge displays an "unknown" status. That's because the code rating is not enabled. See: https://scrutinizer-ci.com/docs/code_rating_system