### PR TITLE
Configure Scrutinizer filter

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,6 +8,10 @@ build:
         override:
           - php-scrutinizer-run
 
+filter:
+    paths:
+        - src/
+
 tools:
   external_code_coverage:
     timeout: 600


### PR DESCRIPTION
By setting this filter we exclude the _tests_ folder from the code coverage report.
Also issues from _.php-cs-fixer.dist.php_ are not relevant.

Doc: https://scrutinizer-ci.com/docs/reviews/excluding_files_from_analysis