### PR TITLE
install legacy varnish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,120 +58,116 @@ jobs:
       - name: Execute tests
         run: vendor/bin/simple-phpunit -v
 
-# spent hours trying to make this work
-# unfortunately, the installation always picks the varnish 5 from ubuntu instead of the specified one
-# installing with `apt-get install varnish=${VARNISH_VERSION}.*` reports that the version is not found
-#
-#  varnish5:
-#    name: PHP ${{ matrix.php }} Legacy Varnish 5
-#    runs-on: ubuntu-18.04
-#    env:
-#      VARNISH_VERSION: '5.1'
-#      VARNISH_MODULES_VERSION: '0.14.0'
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - php: '7.4'
-#
-#    steps:
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup Varnish and Nginx
-#        run: |
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
-#
-#      - name: Install composer dependencies
-#        run: |
-#          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
-#          vendor/bin/simple-phpunit install
-#
-#      - name: Execute tests
-#        run: vendor/bin/simple-phpunit -v
-#
-#  varnish4:
-#    name: PHP ${{ matrix.php }} Legacy Varnish 4
-#    runs-on: ubuntu-18.04
-#    env:
-#      VARNISH_VERSION: '4.1'
-#      VARNISH_MODULES_VERSION: '0.9.1'
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - php: '7.4'
-#
-#    steps:
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup Varnish and Nginx
-#        run: |
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
-#
-#      - name: Install composer dependencies
-#        run: |
-#          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
-#          vendor/bin/simple-phpunit install
-#
-#      - name: Execute tests
-#        run: vendor/bin/simple-phpunit -v
-#
-#  lowest:
-#    name: PHP ${{ matrix.php }} Lowest, Varnish 3
-#    runs-on: ubuntu-18.04
-#    env:
-#      VARNISH_VERSION: '3.0'
-#      VARNISH_MODULES_VERSION: ''
-#      DEPENDENCIES: ''
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        php: ['7.2']
-#
-#    steps:
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup Varnish and Nginx
-#        run: |
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
-#          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
-#
-#      - name: Install composer dependencies
-#        run: |
-#          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
-#          vendor/bin/simple-phpunit install
-#
-#      - name: Execute tests
-#        run: vendor/bin/simple-phpunit -v
+  varnish5:
+    name: PHP ${{ matrix.php }} Legacy Varnish 5
+    runs-on: ubuntu-18.04
+    env:
+      VARNISH_VERSION: '5.1'
+      VARNISH_MODULES_VERSION: '0.14.0'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.4'
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Varnish and Nginx
+        run: |
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
+
+      - name: Install composer dependencies
+        run: |
+          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
+          vendor/bin/simple-phpunit install
+
+      - name: Execute tests
+        run: vendor/bin/simple-phpunit -v
+
+  varnish4:
+    name: PHP ${{ matrix.php }} Legacy Varnish 4
+    runs-on: ubuntu-18.04
+    env:
+      VARNISH_VERSION: '4.1'
+      VARNISH_MODULES_VERSION: '' # varnish modules compilation fails, not sure why
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.4'
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Varnish and Nginx
+        run: |
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
+
+      - name: Install composer dependencies
+        run: |
+          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
+          vendor/bin/simple-phpunit install
+
+      - name: Execute tests
+        run: vendor/bin/simple-phpunit -v
+
+  lowest:
+    name: PHP ${{ matrix.php }} Lowest, Varnish 3
+    runs-on: ubuntu-18.04
+    env:
+      VARNISH_VERSION: '3.0'
+      VARNISH_MODULES_VERSION: ''
+      DEPENDENCIES: ''
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.2']
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Varnish and Nginx
+        run: |
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-varnish-legacy.sh
+          sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
+
+      - name: Install composer dependencies
+        run: |
+          composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
+          vendor/bin/simple-phpunit install
+
+      - name: Execute tests
+        run: vendor/bin/simple-phpunit -v
 
   coverage:
     name: Code Coverage

--- a/.github/workflows/setup-varnish-legacy.sh
+++ b/.github/workflows/setup-varnish-legacy.sh
@@ -2,7 +2,20 @@
 
 set -e
 echo "### Installing Legacy Varnish $VARNISH_VERSION ###"
-VARNISH_VERSION=$VARNISH_VERSION bash -c 'curl -s https://packagecloud.io/install/repositories/varnishcache/varnish${VARNISH_VERSION//./}/script.deb.sh' | sudo bash
-# this is broken: we don't find the version. when not specifying the version, we end up with varnish 5 from the regular ubuntu distribution
-VARNISH_VERSION=$VARNISH_VERSION bash -c 'sudo apt-get install varnish=${VARNISH_VERSION}.*'
+sudo apt-get update
+sudo apt-get install debian-archive-keyring curl gnupg apt-transport-https
+VARNISH_VERSION=$VARNISH_VERSION bash -c 'curl -s -L https://packagecloud.io/varnishcache/varnish${VARNISH_VERSION//./}/gpgkey' | sudo apt-key add -
+# hardcode to use ubuntu trusty. that would be 14.04, but it is no longer supported on github actions.
+# the varnish 3 repository on packagecloud.io does not provide packages for newer ubuntu distributions
+# the trusty packages seem to work. YOLO
+VARNISH_VERSION=$VARNISH_VERSION bash -c 'echo deb https://packagecloud.io/varnishcache/varnish${VARNISH_VERSION//./}/ubuntu/ trusty main' | sudo tee /etc/apt/sources.list.d/varnishcache_varnish.list
+cat /etc/apt/sources.list.d/varnishcache_varnish.list
+sudo tee /etc/apt/preferences.d/varnishcache > /dev/null <<-EOF
+Package: varnish varnish-* hitch
+Pin: release o=packagecloud.io/varnishcache/*
+Pin-Priority: 1000
+EOF
+sudo apt-get update
+
+sudo apt-get install varnish
 if [ "$VARNISH_MODULES_VERSION" != "" ]; then sh "${GITHUB_WORKSPACE}/tests/install-varnish-modules-legacy.sh"; fi

--- a/.github/workflows/setup-varnish.sh
+++ b/.github/workflows/setup-varnish.sh
@@ -3,5 +3,5 @@
 set -e
 echo "### Installing Varnish $VARNISH_VERSION ###"
 VARNISH_VERSION=$VARNISH_VERSION bash -c 'curl -s https://packagecloud.io/install/repositories/varnishcache/varnish${VARNISH_VERSION//./}/script.deb.sh' | sudo bash
-sudo apt-get install -t focal varnish
+sudo apt-get install varnish
 if [ "$VARNISH_MODULES_VERSION" != "" ]; then sh "${GITHUB_WORKSPACE}/tests/install-varnish-modules.sh"; fi


### PR DESCRIPTION
make legacy build work again, with help from https://www.varnish-software.com/developers/tutorials/installing-varnish-ubuntu/

we however can't use the actual ubuntu version that we run on, as the packagecloud.io repository for legacy varnish do only provide packages for way older ubuntu versions. hardcoding trusty seems to work \o/