### PR TITLE
Allow installation with Symfony 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
         - php: '8.1'
           varnish-version: '7.1'
           varnish-modules-version: '0.20.0'
+        - php: '8.2'
+          symfony-version: '7.*'
+        - php: '8.2'
+          varnish-version: '7.1'
+          varnish-modules-version: '0.20.0'
+        - php: '8.3'
+          symfony-version: '7.*'
+        - php: '8.3'
+          varnish-version: '7.1'
+          varnish-modules-version: '0.20.0'
 
     steps:
       - name: Setup PHP

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0",
-        "symfony/options-resolver": "^4.3 || ^5.0 || ^6.0",
+        "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/options-resolver": "^4.3 || ^5.0 || ^6.0 || ^7.0",
         "php-http/client-implementation": "^1.0 || ^2.0",
         "php-http/client-common": "^1.1.0 || ^2.0",
         "php-http/message": "^1.0 || ^2.0",
@@ -35,9 +35,9 @@
         "monolog/monolog": "^1.0",
         "php-http/guzzle7-adapter": "^0.1.1",
         "php-http/mock-client": "^1.2",
-        "symfony/process": "^4.3 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.3 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^5.0 || ^6.0"
+        "symfony/process": "^4.3 || ^5.0 || ^6.0|| ^7.0",
+        "symfony/http-kernel": "^4.3 || ^5.0 || ^6.0|| ^7.0",
+        "symfony/phpunit-bridge": "^5.0 || ^6.0|| ^7.0"
     },
     "conflict": {
         "toflar/psr6-symfony-http-cache-store": "<2.2.1"


### PR DESCRIPTION
Requires another update:

 - [ ] php-http/client-common      2.7.0   requires symfony/options-resolver (~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0) https://github.com/php-http/client-common/pull/232