### PR TITLE
Allow empty tag list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 * Test with PHP 8.2 and 8.3
 * Drop support for PHP < 8.1
 * Parameter and return type declarations where possible.
+* Ignore empty tag lists
 
 2.x
 ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 * Test with PHP 8.2 and 8.3
 * Drop support for PHP < 8.1
 * Parameter and return type declarations where possible.
-* Ignore empty tag lists
+* Ignore empty tag lists passed to `TagCapable::invalidateTags` so you don't need to check if there are tags or not.
 
 2.x
 ===

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -221,7 +221,7 @@ class CacheInvalidator
      *
      * @see TagCapable::tags()
      *
-     * @param array $tags Tags that should be removed/expired from the cache
+     * @param array $tags Tags that should be removed/expired from the cache. An empty tag list is ignored.
      *
      * @return $this
      *
@@ -232,6 +232,10 @@ class CacheInvalidator
         if (!$this->cache instanceof TagCapable) {
             throw UnsupportedProxyOperationException::cacheDoesNotImplement('Tags');
         }
+        if (!$tags) {
+            return $this;
+        }
+
         $this->cache->invalidateTags($tags);
 
         return $this;

--- a/src/ProxyClient/Cloudflare.php
+++ b/src/ProxyClient/Cloudflare.php
@@ -70,6 +70,10 @@ class Cloudflare extends HttpProxyClient implements ClearCapable, PurgeCapable, 
      */
     public function invalidateTags(array $tags)
     {
+        if (!$tags) {
+            return $this;
+        }
+
         $this->queueRequest(
             'POST',
             sprintf(self::API_ENDPOINT.'/zones/%s/purge_cache', $this->options['zone_identifier']),

--- a/src/ProxyClient/Fastly.php
+++ b/src/ProxyClient/Fastly.php
@@ -62,6 +62,10 @@ class Fastly extends HttpProxyClient implements ClearCapable, PurgeCapable, Refr
      */
     public function invalidateTags(array $tags)
     {
+        if (!$tags) {
+            return $this;
+        }
+
         $url = sprintf(self::API_ENDPOINT.'/service/%s/purge', $this->options['service_identifier']);
         $headers = ['Accept' => 'application/json'];
         if (true === $this->options['soft_purge']) {

--- a/src/ProxyClient/Invalidation/TagCapable.php
+++ b/src/ProxyClient/Invalidation/TagCapable.php
@@ -25,7 +25,7 @@ interface TagCapable extends ProxyClient
     /**
      * Remove/Expire cache objects based on cache tags.
      *
-     * @param array $tags Tags that should be removed/expired from the cache
+     * @param array $tags Tags that should be removed/expired from the cache. An empty tag list should be ignored.
      *
      * @return $this
      */

--- a/src/ProxyClient/MultiplexerClient.php
+++ b/src/ProxyClient/MultiplexerClient.php
@@ -107,6 +107,10 @@ class MultiplexerClient implements BanCapable, PurgeCapable, RefreshCapable, Tag
      */
     public function invalidateTags(array $tags)
     {
+        if (!$tags) {
+            return $this;
+        }
+
         $this->invoke(TagCapable::class, 'invalidateTags', [$tags]);
 
         return $this;

--- a/src/ProxyClient/Symfony.php
+++ b/src/ProxyClient/Symfony.php
@@ -69,6 +69,10 @@ class Symfony extends HttpProxyClient implements PurgeCapable, RefreshCapable, T
 
     public function invalidateTags(array $tags)
     {
+        if (!$tags) {
+            return $this;
+        }
+
         $escapedTags = $this->escapeTags($tags);
 
         $chunkSize = $this->determineTagsPerHeader($escapedTags, ',');

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -69,6 +69,10 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
 
     public function invalidateTags(array $tags)
     {
+        if (!$tags) {
+            return $this;
+        }
+
         $banMode = self::TAG_BAN === $this->options['tag_mode'];
 
         // If using BAN's, escape each tag


### PR DESCRIPTION
Fixes `array_chunk(): Argument #2 ($length) must be greater than 0` and removes the need for redundant boilerplate `if` everywhere.