### PR TITLE
use fixed discovery instead of declaring conflict with old guzzlehttp…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,9 @@ jobs:
           sh ${GITHUB_WORKSPACE}/.github/workflows/setup-nginx.sh
 
       - name: Install composer dependencies
+        # Lowest discovery can end up with an incompatible psr7 implementation, see discussion in https://github.com/FriendsOfSymfony/FOSHttpCache/pull/567
         run: |
+          composer require --no-update --no-interaction "guzzlehttp/psr7:2.*"
           composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
 
       - name: Execute tests
@@ -133,6 +135,7 @@ jobs:
 
       - name: Install composer dependencies
         run: |
+          composer require --no-update --no-interaction "guzzlehttp/psr7:2.*"
           composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
 
       - name: Execute tests
@@ -169,6 +172,7 @@ jobs:
 
       - name: Install composer dependencies
         run: |
+          composer require --no-update --no-interaction "guzzlehttp/psr7:2.*"
           composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
         "phpunit/phpunit": "^10.5"
     },
     "conflict": {
-        "toflar/psr6-symfony-http-cache-store": "<2.2.1",
-        "guzzlehttp/psr7": "<2"
+        "toflar/psr6-symfony-http-cache-store": "<2.2.1"
     },
     "suggest": {
         "friendsofsymfony/http-cache-bundle": "For integration with the Symfony framework",


### PR DESCRIPTION
…/psr

the prefer-lowest job goes into an endless loop, see https://github.com/php-http/discovery/pull/263