### PR TITLE
Add fallbackToSmaxage flag to CustomTtlListener and check for isCacheable before calling store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 ------
 
 * Add flag to `CustomTtlListener` for disabling fallback to s-maxage if header not defined.
-* Fix not calling store if Response object is not longer cachable after event listeners.
+* Fix not calling store if Response object is not longer cacheable after event listeners.
 
 2.15.3
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 ------
 
 * Add flag `fallbackToSmaxage` to `CustomTtlListener` to allow controlling fallback to s-maxage if custom TTL header is not defined on the response.
-* Fix: Do not call store if Response object is not longer cacheable after event listeners.
+* Fix for Symfony HttpCache: Do not call store if Response object is not longer cacheable after event listeners. If you use the custom TTL system, this is only a performance improvement, because the TTL of the response would still be 0. With a custom listener that changes the response explicitly to not be cached but does not change s-maxage, this bug might have led to caching responses that should not have been cached
 
 2.15.3
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 2.15.4
 ------
 
-* Fix always use defined `CustomTtlListener` header even if not set.
+* Add flag to `CustomTtlListener` for disabling fallback to s-maxage if header not defined.
 * Fix not calling store if Response object is not longer cachable after event listeners.
 
 2.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 2.15.4
 ------
 
-* Add flag to `CustomTtlListener` for disabling fallback to s-maxage if header not defined.
-* Fix not calling store if Response object is not longer cacheable after event listeners.
+* Add flag `fallbackToSmaxage` to `CustomTtlListener` to allow controlling fallback to s-maxage if custom TTL header is not defined on the response.
+* Fix: Do not call store if Response object is not longer cacheable after event listeners.
 
 2.15.3
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpCache/releases).
 
+2.15.4
+------
+
+* Fix always use defined `CustomTtlListener` header even if not set.
+* Fix not calling store if Response object is not longer cachable after event listeners.
+
 2.15.3
 ------
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -360,7 +360,7 @@ You can enable keeping the custom header with the `keepTtlHeader` parameter::
 
     new CustomTtlListener('My-TTL-Header', keepTtlHeader: true);
 
-By default if the custom ttl header is not found it will fallback to s-maxage.
+By default if the custom ttl header is not present, the listener falls back to the s-maxage cache-control directive.
 To disable this behavior you can set the `fallbackToSmaxage` parameter to false::
 
     new CustomTtlListener('My-TTL-Header', keepTtlHeader: true, fallbackToSmaxage: false);

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -356,6 +356,14 @@ but you can customize that in the listener constructor::
     new CustomTtlListener('My-TTL-Header');
 
 The custom header is removed before sending the response to the client.
+You can enable keeping the custom header with the `keepTtlHeader` parameter::
+
+    new CustomTtlListener('My-TTL-Header', keepTtlHeader: true);
+
+By default if the custom ttl header is not found it will fallback to s-maxage.
+To disable this behavior you can set the `fallbackToSmaxage` parameter to false::
+
+    new CustomTtlListener('My-TTL-Header', keepTtlHeader: true, fallbackToSmaxage: false);
 
 .. _symfony-cache x-debugging:
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -361,7 +361,7 @@ You can enable keeping the custom header with the `keepTtlHeader` parameter::
     new CustomTtlListener('My-TTL-Header', keepTtlHeader: true);
 
 By default if the custom ttl header is not present, the listener falls back to the s-maxage cache-control directive.
-To disable this behavior you can set the `fallbackToSmaxage` parameter to false::
+To disable this behavior, you can set the `fallbackToSmaxage` parameter to false::
 
     new CustomTtlListener('My-TTL-Header', keepTtlHeader: true, fallbackToSmaxage: false);
 

--- a/doc/symfony-cache-configuration.rst
+++ b/doc/symfony-cache-configuration.rst
@@ -363,7 +363,7 @@ You can enable keeping the custom header with the `keepTtlHeader` parameter::
 By default if the custom ttl header is not present, the listener falls back to the s-maxage cache-control directive.
 To disable this behavior, you can set the `fallbackToSmaxage` parameter to false::
 
-    new CustomTtlListener('My-TTL-Header', keepTtlHeader: true, fallbackToSmaxage: false);
+    new CustomTtlListener('My-TTL-Header', fallbackToSmaxage: false);
 
 .. _symfony-cache x-debugging:
 

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -34,6 +34,11 @@ class CustomTtlListener implements EventSubscriberInterface
     private $keepTtlHeader;
 
     /**
+     * @var bool
+     */
+    private $disableFallback;
+
+    /**
      * Header used for backing up the s-maxage.
      *
      * @var string
@@ -41,13 +46,15 @@ class CustomTtlListener implements EventSubscriberInterface
     public const SMAXAGE_BACKUP = 'FOS-Smaxage-Backup';
 
     /**
-     * @param string $ttlHeader     The header name that is used to specify the time to live
-     * @param bool   $keepTtlHeader Keep the custom TTL header on the response for later usage (e.g. debugging)
+     * @param string $ttlHeader       The header name that is used to specify the time to live
+     * @param bool   $keepTtlHeader   Keep the custom TTL header on the response for later usage (e.g. debugging)
+     * @param bool   $disableFallback If the custom TTL header is not set, do not fall back to s-maxage
      */
-    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false)
+    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false, $disableFallback = false)
     {
         $this->ttlHeader = $ttlHeader;
         $this->keepTtlHeader = $keepTtlHeader;
+        $this->disableFallback = $disableFallback;
     }
 
     /**
@@ -59,6 +66,13 @@ class CustomTtlListener implements EventSubscriberInterface
     public function useCustomTtl(CacheEvent $e)
     {
         $response = $e->getResponse();
+
+        if (!$response->headers->has($this->ttlHeader)
+            && false === $this->disableFallback
+        ) {
+            return;
+        }
+
         $backup = $response->headers->hasCacheControlDirective('s-maxage')
             ? $response->headers->getCacheControlDirective('s-maxage')
             : 'false'

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -46,8 +46,8 @@ class CustomTtlListener implements EventSubscriberInterface
     public const SMAXAGE_BACKUP = 'FOS-Smaxage-Backup';
 
     /**
-     * @param string $ttlHeader       The header name that is used to specify the time to live
-     * @param bool   $keepTtlHeader   Keep the custom TTL header on the response for later usage (e.g. debugging)
+     * @param string $ttlHeader         The header name that is used to specify the time to live
+     * @param bool   $keepTtlHeader     Keep the custom TTL header on the response for later usage (e.g. debugging)
      * @param bool   $fallbackToSmaxage If the custom TTL header is not set, should s-maxage be used?
      */
     public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false, $fallbackToSmaxage = true)

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -91,11 +91,6 @@ class CustomTtlListener implements EventSubscriberInterface
     public function cleanResponse(CacheEvent $e)
     {
         $response = $e->getResponse();
-        if (!$response->headers->has($this->ttlHeader)
-            && !$response->headers->has(static::SMAXAGE_BACKUP)
-        ) {
-            return;
-        }
 
         if ($response->headers->has(static::SMAXAGE_BACKUP)) {
             $smaxage = $response->headers->get(static::SMAXAGE_BACKUP);
@@ -104,12 +99,15 @@ class CustomTtlListener implements EventSubscriberInterface
             } else {
                 $response->headers->addCacheControlDirective('s-maxage', $smaxage);
             }
+
+            $response->headers->remove(static::SMAXAGE_BACKUP);
         }
 
-        if (!$this->keepTtlHeader) {
+        if ($response->headers->has($this->ttlHeader)
+            && !$this->keepTtlHeader
+        ) {
             $response->headers->remove($this->ttlHeader);
         }
-        $response->headers->remove(static::SMAXAGE_BACKUP);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -59,15 +59,16 @@ class CustomTtlListener implements EventSubscriberInterface
     public function useCustomTtl(CacheEvent $e)
     {
         $response = $e->getResponse();
-        if (!$response->headers->has($this->ttlHeader)) {
-            return;
-        }
         $backup = $response->headers->hasCacheControlDirective('s-maxage')
             ? $response->headers->getCacheControlDirective('s-maxage')
             : 'false'
         ;
         $response->headers->set(static::SMAXAGE_BACKUP, $backup);
-        $response->setTtl($response->headers->get($this->ttlHeader));
+        $response->setTtl(
+            $response->headers->has($this->ttlHeader)
+                ? $response->headers->get($this->ttlHeader)
+                : 0
+        );
     }
 
     /**

--- a/src/SymfonyCache/CustomTtlListener.php
+++ b/src/SymfonyCache/CustomTtlListener.php
@@ -36,7 +36,7 @@ class CustomTtlListener implements EventSubscriberInterface
     /**
      * @var bool
      */
-    private $disableFallback;
+    private $fallbackToSmaxage;
 
     /**
      * Header used for backing up the s-maxage.
@@ -48,13 +48,13 @@ class CustomTtlListener implements EventSubscriberInterface
     /**
      * @param string $ttlHeader       The header name that is used to specify the time to live
      * @param bool   $keepTtlHeader   Keep the custom TTL header on the response for later usage (e.g. debugging)
-     * @param bool   $disableFallback If the custom TTL header is not set, do not fall back to s-maxage
+     * @param bool   $fallbackToSmaxage If the custom TTL header is not set, should s-maxage be used?
      */
-    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false, $disableFallback = false)
+    public function __construct($ttlHeader = 'X-Reverse-Proxy-TTL', $keepTtlHeader = false, $fallbackToSmaxage = true)
     {
         $this->ttlHeader = $ttlHeader;
         $this->keepTtlHeader = $keepTtlHeader;
-        $this->disableFallback = $disableFallback;
+        $this->fallbackToSmaxage = $fallbackToSmaxage;
     }
 
     /**
@@ -68,7 +68,7 @@ class CustomTtlListener implements EventSubscriberInterface
         $response = $e->getResponse();
 
         if (!$response->headers->has($this->ttlHeader)
-            && false === $this->disableFallback
+            && true === $this->fallbackToSmaxage
         ) {
             return;
         }
@@ -103,9 +103,7 @@ class CustomTtlListener implements EventSubscriberInterface
             $response->headers->remove(static::SMAXAGE_BACKUP);
         }
 
-        if ($response->headers->has($this->ttlHeader)
-            && !$this->keepTtlHeader
-        ) {
+        if (!$this->keepTtlHeader) {
             $response->headers->remove($this->ttlHeader);
         }
     }

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -109,7 +109,11 @@ trait EventDispatchingHttpCache
     {
         $response = $this->dispatch(Events::PRE_STORE, $request, $response);
 
-        parent::store($request, $response);
+        // CustomTtlListener or other Listener or Subscribers might have set a non-cacheable response so we need revalidate this
+        // So store is only called when cacheable like Symfony core would do: https://github.com/symfony/symfony/blob/v7.1.2/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L409
+        if ($response->isCacheable()) {
+            parent::store($request, $response);
+        }
     }
 
     /**

--- a/src/SymfonyCache/EventDispatchingHttpCache.php
+++ b/src/SymfonyCache/EventDispatchingHttpCache.php
@@ -109,8 +109,8 @@ trait EventDispatchingHttpCache
     {
         $response = $this->dispatch(Events::PRE_STORE, $request, $response);
 
-        // CustomTtlListener or other Listener or Subscribers might have set a non-cacheable response so we need revalidate this
-        // So store is only called when cacheable like Symfony core would do: https://github.com/symfony/symfony/blob/v7.1.2/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L409
+        // CustomTtlListener or other Listener or Subscribers might have changed the response to become non-cacheable, revalidate.
+        // Only call store for a cacheable response like Symfony core does: https://github.com/symfony/symfony/blob/v7.1.2/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L409
         if ($response->isCacheable()) {
             parent::store($request, $response);
         }

--- a/tests/Functional/Fixtures/Symfony/AppKernel.php
+++ b/tests/Functional/Fixtures/Symfony/AppKernel.php
@@ -31,18 +31,21 @@ class AppKernel implements HttpKernelInterface
             case '/cache':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
+                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/tags':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('X-Cache-Tags', 'tag1,tag2');
+                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/tags_multi_header':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('X-Cache-Tags', ['tag1', 'tag2']);
+                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/negotiation':
@@ -50,6 +53,7 @@ class AppKernel implements HttpKernelInterface
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('Content-Type', $request->headers->get('Accept'));
                 $response->setVary('Accept');
+                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
         }

--- a/tests/Functional/Fixtures/Symfony/AppKernel.php
+++ b/tests/Functional/Fixtures/Symfony/AppKernel.php
@@ -31,21 +31,18 @@ class AppKernel implements HttpKernelInterface
             case '/cache':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
-                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/tags':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('X-Cache-Tags', 'tag1,tag2');
-                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/tags_multi_header':
                 $response = new Response(microtime(true));
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('X-Cache-Tags', ['tag1', 'tag2']);
-                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
             case '/negotiation':
@@ -53,7 +50,6 @@ class AppKernel implements HttpKernelInterface
                 $response->setCache(['max_age' => 3600, 'public' => true]);
                 $response->headers->set('Content-Type', $request->headers->get('Accept'));
                 $response->setVary('Accept');
-                $response->headers->set('X-Reverse-Proxy-TTL', '3600');
 
                 return $response;
         }

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -83,6 +83,23 @@ class CustomTtlListenerTest extends TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('33', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+
+    public function testNoCustomTtlNoFallback()
+    {
+        $ttlListener = new CustomTtlListener('X-Reverse-Proxy-TTL', false, true);
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, [
+            'Cache-Control' => 'max-age=30, s-maxage=33',
+        ]);
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->useCustomTtl($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('0', $response->headers->getCacheControlDirective('s-maxage'));
         $this->assertTrue($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
     }
@@ -94,6 +111,26 @@ class CustomTtlListenerTest extends TestCase
         $response = new Response('', 200, [
             'X-Reverse-Proxy-TTL' => '120',
             'Cache-Control' => 's-maxage=120, max-age=30',
+            CustomTtlListener::SMAXAGE_BACKUP => '60',
+        ]);
+        $event = new CacheEvent($this->kernel, $request, $response);
+
+        $ttlListener->cleanResponse($event);
+        $response = $event->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->headers->hasCacheControlDirective('s-maxage'));
+        $this->assertSame('60', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertFalse($response->headers->has('X-Reverse-Proxy-TTL'));
+        $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
+    }
+
+    public function testCleanupNoReverseProxyTtl()
+    {
+        $ttlListener = new CustomTtlListener();
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = new Response('', 200, [
+            'Cache-Control' => 's-maxage=0, max-age=30',
             CustomTtlListener::SMAXAGE_BACKUP => '60',
         ]);
         $event = new CacheEvent($this->kernel, $request, $response);

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -89,7 +89,7 @@ class CustomTtlListenerTest extends TestCase
 
     public function testNoCustomTtlNoFallback()
     {
-        $ttlListener = new CustomTtlListener('X-Reverse-Proxy-TTL', false, true);
+        $ttlListener = new CustomTtlListener('X-Reverse-Proxy-TTL', false, false);
         $request = Request::create('http://example.com/foo', 'GET');
         $response = new Response('', 200, [
             'Cache-Control' => 'max-age=30, s-maxage=33',

--- a/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
+++ b/tests/Unit/SymfonyCache/CustomTtlListenerTest.php
@@ -83,8 +83,8 @@ class CustomTtlListenerTest extends TestCase
         $response = $event->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('33', $response->headers->getCacheControlDirective('s-maxage'));
-        $this->assertFalse($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
+        $this->assertSame('0', $response->headers->getCacheControlDirective('s-maxage'));
+        $this->assertTrue($response->headers->has(CustomTtlListener::SMAXAGE_BACKUP));
     }
 
     public function testCleanup()


### PR DESCRIPTION
We have the `CustomTtlListener` enabled but we have controllers which set only a `s-maxage` the `s-maxage` is in our case always only for browsers and should never used by Symfony or Varnished HttpCache / reverse proxy.

The current `CustomTtlListener` still fallbacks always back to s-maxage / maxage this should in my opinion not the case if `CustomTtlListener` the HttpCache should only listen on the configured header and ignore the max age headers.

/cc @Toflar @dbu Alternativily we should also add a option to the `CustomTtlListener` `disableFallback` / `enableFallback`.

**Update**

As discussed below we will add additional `fallbackToSmaxage = true` parameter to make it possible to disable that fallback mechanism.

Additional this pull request adds a recheck for `$response->isCachable` after the listeners were run. That not only improve performance for response setting a ttl to 0 but its now possible to set a response to private in a preHandle listener event to also disable the caching.