### PR TITLE
fix(doc): typo in the header name for Fastly

### DIFF
--- a/doc/fastly-configuration.rst
+++ b/doc/fastly-configuration.rst
@@ -13,7 +13,7 @@ Tagging
 ~~~~~~~
 
 Fastly supports cache tagging out of the box.
-Configure the tag header to ``Surrogate-Keys``. (``fos_http_cache.tags.response_header`` if you use FOSHttpCacheBundle)
+Configure the tag header to ``Surrogate-Key``. (``fos_http_cache.tags.response_header`` if you use FOSHttpCacheBundle)
 
 Purge
 ~~~~~


### PR DESCRIPTION
doc https://www.fastly.com/documentation/reference/http/http-headers/Surrogate-Key/