### PR TITLE
feat(doc): add more information on Fastly tag keys

### DIFF
--- a/doc/fastly-configuration.rst
+++ b/doc/fastly-configuration.rst
@@ -13,7 +13,7 @@ Tagging
 ~~~~~~~
 
 Fastly supports cache tagging out of the box.
-Configure the tag header to ``Surrogate-Key``. (``fos_http_cache.tags.response_header`` if you use FOSHttpCacheBundle)
+Configure the tag header to ``Surrogate-Key``. (``fos_http_cache.tags.response_header`` as well as ``fos_http_cache.tags.separator`` to `` `` if you use FOSHttpCacheBundle)
 
 Purge
 ~~~~~


### PR DESCRIPTION
Hey, here is a PR after https://github.com/FriendsOfSymfony/FOSHttpCache/pull/588
Fastly needs a separator ` ` so it could be wise to state it here :) (instead of default `,`)

https://www.fastly.com/documentation/reference/http/http-headers/Surrogate-Key/
<img width="669" alt="Capture d’écran 2025-01-07 à 18 46 17" src="https://github.com/user-attachments/assets/4a075f68-6766-4b3a-b398-b4e87872d644" />


wdyt? thank you,