### PR TITLE
Escape special characters in `Varnish::banPath()` host patterns

### DIFF
--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -110,7 +110,7 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
             if (!count($hosts)) {
                 throw new InvalidArgumentException('Either supply a list of hosts or null, but not an empty array.');
             }
-            $hosts = '^('.implode('|', $hosts).')$';
+            $hosts = '^('.implode('|', array_map('preg_quote', $hosts)).')$';
         }
 
         $headers = [


### PR DESCRIPTION
Hostnames contain characters such as `.`, which should be escaped in a regex in order to match literally.