### PR TITLE
Escape special characters in Varnish::banPath() host patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ See also the [GitHub releases page](https://github.com/FriendsOfSymfony/FOSHttpC
 3.x
 ===
 
+3.1.1
+-----
+
+### Varnish Cache
+
+* Fixed `banPath` to escape array of host names to be a correct regular expression.
+
 3.1.0
 -----
 

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -110,7 +110,7 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
             if (!count($hosts)) {
                 throw new InvalidArgumentException('Either supply a list of hosts or null, but not an empty array.');
             }
-            $hosts = '^('.implode('|', $hosts).')$';
+            $hosts = '^('.implode('|', array_map(preg_quote(...), $hosts)).')$';
         }
 
         $headers = [

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -71,7 +71,7 @@ class VarnishTest extends TestCase
             \Mockery::on(
                 function (RequestInterface $request) {
                     $this->assertEquals('BAN', $request->getMethod());
-                    $this->assertEquals('^(fos.lo|fos2.lo)$', $request->getHeaderLine('X-Host'));
+                    $this->assertEquals('^(fos\.lo|fos2\.lo)$', $request->getHeaderLine('X-Host'));
                     $this->assertEquals('/articles/.*', $request->getHeaderLine('X-Url'));
                     $this->assertEquals('text/html', $request->getHeaderLine('X-Content-Type'));
 


### PR DESCRIPTION
fix #592