### PR TITLE
add support for prefix invalidation

### DIFF
--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -19,17 +19,17 @@ Supported invalidation methods
 Not all clients support all :ref:`invalidation methods <invalidation methods>`.
 This table provides of methods supported by each proxy client:
 
-============= ======= ======= ======= ======= =======
-Client        Purge   Refresh Ban     Tagging Clear
-============= ======= ======= ======= ======= =======
+============= ======= ======= ======= ======= ====== =======
+Client        Purge   Refresh Ban     Tagging Prefix Clear
+============= ======= ======= ======= ======= ====== =======
 Varnish       ✓       ✓       ✓       ✓
-Fastly        ✓       ✓               ✓       ✓
+Fastly        ✓       ✓               ✓              ✓
 NGINX         ✓       ✓
-Symfony Cache ✓       ✓               ✓ (1)   ✓ (1)
-Cloudflare    ✓                       ✓ (2)   ✓
-Noop          ✓       ✓       ✓       ✓       ✓
-Multiplexer   ✓       ✓       ✓       ✓       ✓
-============= ======= ======= ======= ======= =======
+Symfony Cache ✓       ✓               ✓ (1)          ✓ (1)
+Cloudflare    ✓                       ✓ (2)   ✓ (2)  ✓
+Noop          ✓       ✓       ✓       ✓              ✓
+Multiplexer   ✓       ✓       ✓       ✓              ✓
+============= ======= ======= ======= ======= ====== =======
 
 | (1): Only when using `Toflar Psr6Store`_.
 | (2): Only available with `Cloudflare Enterprise`_.
@@ -357,7 +357,7 @@ the HttpDispatcher is not available for Cloudflare)::
     Cloudflare supports different cache purge methods depending on your account.
     All Cloudflare accounts support purging the cache by URL and clearing all
     cache items. You need a `Cloudflare Enterprise`_ account to purge by cache
-    tags.
+    tags or prefixes.
 
 Zone identifier
 ^^^^^^^^^^^^^^^

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -22,7 +22,7 @@ This table provides of methods supported by each proxy client:
 ============= ======= ======= ======= ======= ====== =======
 Client        Purge   Refresh Ban     Tagging Prefix Clear
 ============= ======= ======= ======= ======= ====== =======
-Varnish       ✓       ✓       ✓       ✓
+Varnish       ✓       ✓       ✓       ✓       ✓
 Fastly        ✓       ✓               ✓              ✓
 NGINX         ✓       ✓
 Symfony Cache ✓       ✓               ✓ (1)          ✓ (1)

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -27,8 +27,8 @@ Fastly        ✓       ✓               ✓              ✓
 NGINX         ✓       ✓
 Symfony Cache ✓       ✓               ✓ (1)          ✓ (1)
 Cloudflare    ✓                       ✓ (2)   ✓ (2)  ✓
-Noop          ✓       ✓       ✓       ✓              ✓
-Multiplexer   ✓       ✓       ✓       ✓              ✓
+Noop          ✓       ✓       ✓       ✓       ✓      ✓
+Multiplexer   ✓       ✓       ✓       ✓       ✓      ✓
 ============= ======= ======= ======= ======= ====== =======
 
 | (1): Only when using `Toflar Psr6Store`_.

--- a/doc/proxy-clients.rst
+++ b/doc/proxy-clients.rst
@@ -19,18 +19,19 @@ Supported invalidation methods
 Not all clients support all :ref:`invalidation methods <invalidation methods>`.
 This table provides of methods supported by each proxy client:
 
-============= ======= ======= ======= ======= ====== =======
-Client        Purge   Refresh Ban     Tagging Prefix Clear
-============= ======= ======= ======= ======= ====== =======
+============= ======= ======= ======= ======= ========= =======
+Client        Purge   Refresh Ban     Tagging Prefix(*) Clear
+============= ======= ======= ======= ======= ========= =======
 Varnish       ✓       ✓       ✓       ✓       ✓
-Fastly        ✓       ✓               ✓              ✓
+Fastly        ✓       ✓               ✓                 ✓
 NGINX         ✓       ✓
-Symfony Cache ✓       ✓               ✓ (1)          ✓ (1)
-Cloudflare    ✓                       ✓ (2)   ✓ (2)  ✓
-Noop          ✓       ✓       ✓       ✓       ✓      ✓
-Multiplexer   ✓       ✓       ✓       ✓       ✓      ✓
-============= ======= ======= ======= ======= ====== =======
+Symfony Cache ✓       ✓               ✓ (1)             ✓ (1)
+Cloudflare    ✓                       ✓ (2)   ✓ (2)     ✓
+Noop          ✓       ✓       ✓       ✓       ✓         ✓
+Multiplexer   ✓       ✓       ✓       ✓       ✓         ✓
+============= ======= ======= ======= ======= ========= =======
 
+| (*): A limited version of Ban, that allows to invalidate by the beginning of a path
 | (1): Only when using `Toflar Psr6Store`_.
 | (2): Only available with `Cloudflare Enterprise`_.
 

--- a/src/CacheInvalidator.php
+++ b/src/CacheInvalidator.php
@@ -18,6 +18,7 @@ use FOS\HttpCache\Exception\ProxyUnreachableException;
 use FOS\HttpCache\Exception\UnsupportedProxyOperationException;
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\ClearCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
@@ -212,6 +213,20 @@ class CacheInvalidator
         }
 
         $this->cache->invalidateTags($tags);
+
+        return $this;
+    }
+
+    public function invalidatePrefixes(array $prefixes): static
+    {
+        if (!$this->cache instanceof PrefixCapable) {
+            throw UnsupportedProxyOperationException::cacheDoesNotImplement('Prefixes');
+        }
+        if (!$prefixes) {
+            return $this;
+        }
+
+        $this->cache->invalidatePrefixes($prefixes);
 
         return $this;
     }

--- a/src/ProxyClient/Cloudflare.php
+++ b/src/ProxyClient/Cloudflare.php
@@ -92,7 +92,7 @@ class Cloudflare extends HttpProxyClient implements ClearCapable, PrefixCapable,
      * {@inheritdoc}
      *
      * URL prefix only available with Cloudflare enterprise plans.
-     * 
+     *
      * The prefixes need to include the domain name, but not the protocol, e.g. "www.example.com/path"
      *
      * @see https://developers.cloudflare.com/api/resources/cache/methods/purge/

--- a/src/ProxyClient/Cloudflare.php
+++ b/src/ProxyClient/Cloudflare.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\ClearCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -27,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Simon Jones <simon@studio24.net>
  */
-class Cloudflare extends HttpProxyClient implements ClearCapable, PurgeCapable, TagCapable
+class Cloudflare extends HttpProxyClient implements ClearCapable, PrefixCapable, PurgeCapable, TagCapable
 {
     /**
      * @see https://api.cloudflare.com/#getting-started-endpoints
@@ -82,6 +83,30 @@ class Cloudflare extends HttpProxyClient implements ClearCapable, PurgeCapable, 
             [],
             false,
             json_encode(['tags' => $tags], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)
+        );
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * URL prefix only available with Cloudflare enterprise plans
+     *
+     * @see https://developers.cloudflare.com/api/resources/cache/methods/purge/
+     */
+    public function invalidatePrefixes(array $prefixes): static
+    {
+        if (!$prefixes) {
+            return $this;
+        }
+
+        $this->queueRequest(
+            'POST',
+            sprintf(self::API_ENDPOINT.'/zones/%s/purge_cache', $this->options['zone_identifier']),
+            [],
+            false,
+            json_encode(['prefixes' => $prefixes], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)
         );
 
         return $this;

--- a/src/ProxyClient/Cloudflare.php
+++ b/src/ProxyClient/Cloudflare.php
@@ -91,7 +91,9 @@ class Cloudflare extends HttpProxyClient implements ClearCapable, PrefixCapable,
     /**
      * {@inheritdoc}
      *
-     * URL prefix only available with Cloudflare enterprise plans
+     * URL prefix only available with Cloudflare enterprise plans.
+     * 
+     * The prefixes need to include the domain name, but not the protocol, e.g. "www.example.com/path"
      *
      * @see https://developers.cloudflare.com/api/resources/cache/methods/purge/
      */

--- a/src/ProxyClient/Invalidation/PrefixCapable.php
+++ b/src/ProxyClient/Invalidation/PrefixCapable.php
@@ -14,18 +14,15 @@ namespace FOS\HttpCache\ProxyClient\Invalidation;
 use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
- * An HTTP cache that supports invalidation by a cache tag, that is, removing
- * or expiring objects from the cache tagged with a given tag or set of tags.
- *
- * HTTP responses must carry the tags header name with the tags header value
- * for tag invalidation to work.
+ * An HTTP cache that supports invalidation by a prefix, that is, removing
+ * or expiring objects from the cache with a given prefix or set of prefixes.
  */
 interface PrefixCapable extends ProxyClient
 {
     /**
-     * Remove/Expire cache objects based on cache tags.
+     * Remove/Expire cache objects based on URL prefixes.
      *
-     * @param string[] $tags Tags that should be removed/expired from the cache. An empty tag list should be ignored.
+     * @param string[] $prefixes Prefixed objects that should be removed/expired from the cache. An empty prefix list should be ignored.
      */
     public function invalidatePrefixes(array $prefixes): static;
 }

--- a/src/ProxyClient/Invalidation/PrefixCapable.php
+++ b/src/ProxyClient/Invalidation/PrefixCapable.php
@@ -15,7 +15,7 @@ use FOS\HttpCache\ProxyClient\ProxyClient;
 
 /**
  * An HTTP cache that supports invalidation by a prefix, that is, removing
- * or expiring objects from the cache with a given prefix or set of prefixes.
+ * or expiring objects from the cache starting with the given string or strings.
  */
 interface PrefixCapable extends ProxyClient
 {

--- a/src/ProxyClient/Invalidation/PrefixCapable.php
+++ b/src/ProxyClient/Invalidation/PrefixCapable.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCache package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCache\ProxyClient\Invalidation;
+
+use FOS\HttpCache\ProxyClient\ProxyClient;
+
+/**
+ * An HTTP cache that supports invalidation by a cache tag, that is, removing
+ * or expiring objects from the cache tagged with a given tag or set of tags.
+ *
+ * HTTP responses must carry the tags header name with the tags header value
+ * for tag invalidation to work.
+ */
+interface PrefixCapable extends ProxyClient
+{
+    /**
+     * Remove/Expire cache objects based on cache tags.
+     *
+     * @param string[] $tags Tags that should be removed/expired from the cache. An empty tag list should be ignored.
+     */
+    public function invalidatePrefixes(array $prefixes): static;
+}

--- a/src/ProxyClient/MultiplexerClient.php
+++ b/src/ProxyClient/MultiplexerClient.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\ProxyClient;
 use FOS\HttpCache\Exception\InvalidArgumentException;
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\ClearCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
@@ -23,7 +24,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
  *
  * @author Emanuele Panzeri <thepanz@gmail.com>
  */
-class MultiplexerClient implements BanCapable, PurgeCapable, RefreshCapable, TagCapable, ClearCapable
+class MultiplexerClient implements BanCapable, PrefixCapable, PurgeCapable, RefreshCapable, TagCapable, ClearCapable
 {
     /**
      * @var ProxyClient[]
@@ -89,6 +90,21 @@ class MultiplexerClient implements BanCapable, PurgeCapable, RefreshCapable, Tag
         }
 
         $this->invoke(TagCapable::class, 'invalidateTags', [$tags]);
+
+        return $this;
+    }
+
+    /**
+     * Forwards prefix invalidation request to all clients.
+     *
+     * {@inheritdoc}
+     */
+    public function invalidatePrefixes(array $prefixes): static
+    {
+        if (!$prefixes) {
+            return $this;
+        }
+        $this->invoke(PrefixCapable::class, 'invalidatePrefixes', [$prefixes]);
 
         return $this;
     }

--- a/src/ProxyClient/Noop.php
+++ b/src/ProxyClient/Noop.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\ClearCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
@@ -26,7 +27,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
  *
  * @author Gavin Staniforth <gavin@gsdev.me>
  */
-class Noop implements ProxyClient, BanCapable, PurgeCapable, RefreshCapable, TagCapable, ClearCapable
+class Noop implements ProxyClient, BanCapable, PrefixCapable, PurgeCapable, RefreshCapable, TagCapable, ClearCapable
 {
     public function ban(array $headers): static
     {
@@ -39,6 +40,11 @@ class Noop implements ProxyClient, BanCapable, PurgeCapable, RefreshCapable, Tag
     }
 
     public function invalidateTags(array $tags): static
+    {
+        return $this;
+    }
+
+    public function invalidatePrefixes(array $prefixes): static
     {
         return $this;
     }

--- a/src/ProxyClient/Varnish.php
+++ b/src/ProxyClient/Varnish.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCache\ProxyClient;
 
 use FOS\HttpCache\Exception\InvalidArgumentException;
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
@@ -36,7 +37,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author David de Boer <david@driebit.nl>
  */
-class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, RefreshCapable, TagCapable
+class Varnish extends HttpProxyClient implements BanCapable, PrefixCapable, PurgeCapable, RefreshCapable, TagCapable
 {
     public const HTTP_METHOD_BAN = 'BAN';
 
@@ -125,6 +126,22 @@ class Varnish extends HttpProxyClient implements BanCapable, PurgeCapable, Refre
         }
 
         return $this->ban($headers);
+    }
+
+    public function invalidatePrefixes(array $prefixes): static
+    {
+        if (!$prefixes) {
+            return $this;
+        }
+
+        foreach ($prefixes as $prefix) {
+            $parts = explode('/', $prefix, 2);
+            $host = $parts[0];
+            $path = isset($parts[1]) ? '/'.$parts[1] : '/';
+            $this->banPath($path, null, $host);
+        }
+
+        return $this;
     }
 
     public function purge(string $url, array $headers = []): static

--- a/tests/Unit/ProxyClient/CloudflareTest.php
+++ b/tests/Unit/ProxyClient/CloudflareTest.php
@@ -71,6 +71,28 @@ class CloudflareTest extends TestCase
         $cloudflare->invalidateTags(['tag-one', 'tag-two']);
     }
 
+    public function testInvalidatePrefixesPurge(): void
+    {
+        $cloudflare = $this->getProxyClient();
+
+        $this->httpDispatcher->shouldReceive('invalidate')->once()->with(
+            \Mockery::on(
+                function (RequestInterface $request) {
+                    $this->assertEquals('POST', $request->getMethod());
+                    $this->assertEquals('Bearer '.self::AUTH_TOKEN, current($request->getHeader('Authorization')));
+                    $this->assertEquals(sprintf('/client/v4/zones/%s/purge_cache', self::ZONE_IDENTIFIER), $request->getRequestTarget());
+
+                    $this->assertEquals('{"prefixes":["example.com/one/","example.com/two/"]}', $request->getBody()->getContents());
+
+                    return true;
+                }
+            ),
+            false
+        );
+
+        $cloudflare->invalidateTags(['example.com/one/', 'example.com/two/']);
+    }
+
     public function testPurge(): void
     {
         $cloudflare = $this->getProxyClient();

--- a/tests/Unit/ProxyClient/CloudflareTest.php
+++ b/tests/Unit/ProxyClient/CloudflareTest.php
@@ -90,7 +90,7 @@ class CloudflareTest extends TestCase
             false
         );
 
-        $cloudflare->invalidateTags(['example.com/one/', 'example.com/two/']);
+        $cloudflare->invalidatePrefixes(['example.com/one/', 'example.com/two/']);
     }
 
     public function testPurge(): void

--- a/tests/Unit/ProxyClient/MultiplexerClientTest.php
+++ b/tests/Unit/ProxyClient/MultiplexerClientTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCache\Tests\Unit\ProxyClient;
 use FOS\HttpCache\Exception\InvalidArgumentException;
 use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\ClearCapable;
+use FOS\HttpCache\ProxyClient\Invalidation\PrefixCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
@@ -101,6 +102,21 @@ class MultiplexerClientTest extends TestCase
         $multiplexer = new MultiplexerClient([$mockClient]);
 
         $this->assertSame($multiplexer, $multiplexer->invalidateTags($tags));
+    }
+
+    public function testInvalidatePrefixes(): void
+    {
+        $prefixes = ['example.com/one/', 'example.com/two/'];
+
+        $mockClient = \Mockery::mock(PrefixCapable::class)
+            ->shouldReceive('invalidatePrefixes')
+            ->once()
+            ->with($prefixes)
+            ->getMock();
+
+        $multiplexer = new MultiplexerClient([$mockClient]);
+
+        $this->assertSame($multiplexer, $multiplexer->invalidatePrefixes($prefixes));
     }
 
     public function testRefresh(): void

--- a/tests/Unit/ProxyClient/NoopTest.php
+++ b/tests/Unit/ProxyClient/NoopTest.php
@@ -33,6 +33,11 @@ class NoopTest extends TestCase
         $this->assertSame($this->noop, $this->noop->invalidateTags(['tag123']));
     }
 
+    public function testInvalidatePrefixes(): void
+    {
+        $this->assertSame($this->noop, $this->noop->invalidatePrefixes(['example.com/one/']));
+    }
+
     public function testBanPath(): void
     {
         $this->assertSame($this->noop, $this->noop->banPath('/123'));

--- a/tests/Unit/ProxyClient/VarnishTest.php
+++ b/tests/Unit/ProxyClient/VarnishTest.php
@@ -236,4 +236,23 @@ class VarnishTest extends TestCase
 
         $varnish->refresh('/fresh');
     }
+
+    public function testInvalidatePrefixes(): void
+    {
+        $varnish = new Varnish($this->httpDispatcher);
+        $this->httpDispatcher->shouldReceive('invalidate')->once()->with(
+            \Mockery::on(
+                function (RequestInterface $request) {
+                    $this->assertEquals('BAN', $request->getMethod());
+                    $this->assertEquals('example.org', $request->getHeaderLine('X-Host'));
+                    $this->assertEquals('/one/', $request->getHeaderLine('X-Url'));
+                    $this->assertEquals('.*', $request->getHeaderLine('X-Content-Type'));
+
+                    return true;
+                }
+            ),
+            false
+        );
+        $varnish->invalidatePrefixes(['example.org/one/']);
+    }
 }


### PR DESCRIPTION
Cloudflare supports the [invalidation by prefix](https://developers.cloudflare.com/api/resources/cache/methods/purge/#(params)%200%20%3E%20(param)%20body%20%3E%20(schema)%20%3E%20(variant)%202%20%3E%20(property)%20prefixes).
That PR adds support for that method.